### PR TITLE
Rely on UIKit to detect screen appearances

### DIFF
--- a/Example/Example/AppCore.swift
+++ b/Example/Example/AppCore.swift
@@ -99,47 +99,49 @@ func initializeApp() -> some View {
   )
 
   let pathBuilder: PathBuilder = .screen( // /home
-      content: { (_: HomeScreen) in
-        HomeView(
-          store: appStore.scope(
-            state: \.home,
-            action: AppAction.home
-          )
+    onAppear: { _ in print("HomeView appeared") },
+    content: { (_: HomeScreen) in
+      HomeView(
+        store: appStore.scope(
+          state: \.home,
+          action: AppAction.home
         )
-      },
-      nesting: .anyOf(
-        .screen( // detail?id=123
-          content: { (screen: DetailScreen) in
-            IfLetStore(
-              appStore.scope(
-                state: { state in
-                  state.details.first(where: { $0.id == screen.detailID }) },
-                action: { action in AppAction.detail(id: screen.detailID, action) }
-              ),
-              then: { detailStore in
-                DetailView(
-                  store: detailStore
-                )
-              }
-            )
-          },
-          nesting: .screen( // settings
-            content: { (screen: SettingsScreen) in
-              SettingsView(store: appStore.scope(state: \.settings, action: AppAction.settings))
+      )
+    },
+    nesting: .anyOf(
+      .screen( // detail?id=123
+        content: { (screen: DetailScreen) in
+          IfLetStore(
+            appStore.scope(
+              state: { state in
+                state.details.first(where: { $0.id == screen.detailID }) },
+              action: { action in AppAction.detail(id: screen.detailID, action) }
+            ),
+            then: { detailStore in
+              DetailView(
+                store: detailStore
+              )
             }
           )
-        ),
-        .screen( // settings
+        },
+        nesting: .screen( // settings
           content: { (screen: SettingsScreen) in
             SettingsView(store: appStore.scope(state: \.settings, action: AppAction.settings))
           }
         )
+      ),
+      .screen( // settings
+        content: { (screen: SettingsScreen) in
+          SettingsView(store: appStore.scope(state: \.settings, action: AppAction.settings))
+        }
       )
     )
+  )
 
   return Root(
     dataSource: dataSource,
     pathBuilder: pathBuilder
   )
+  .environment(\.treatSheetDismissAsAppearInPresenter, true)
 }
 

--- a/Sources/ComposableNavigator/Helpers/UIKitOnAppear.swift
+++ b/Sources/ComposableNavigator/Helpers/UIKitOnAppear.swift
@@ -1,0 +1,34 @@
+import UIKit
+import SwiftUI
+
+struct UIKitAppear: UIViewControllerRepresentable {
+    final class UIAppearViewController: UIViewController {
+        var action: () -> Void = {}
+
+        override func viewDidAppear(_ animated: Bool) {
+            action()
+        }
+    }
+
+    let action: () -> Void
+
+    func makeUIViewController(context: Context) -> UIAppearViewController {
+       let vc = UIAppearViewController()
+        vc.action = action
+        return vc
+    }
+
+    func updateUIViewController(_ controller: UIAppearViewController, context: Context) { }
+}
+
+extension View {
+    /**
+    Unfortunately, onAppear is broken in SwiftUI iOS >14.
+    Therefore, we fallback to UIKit's viewDidAppear method in `Routed<Content>` to determine when a screen is shown.
+
+    [Apple Developer Forums Discussion](https://developer.apple.com/forums/thread/655338)
+    */
+    func uiKitOnAppear(_ perform: @escaping () -> Void) -> some View {
+        self.background(UIKitAppear(action: perform))
+    }
+}

--- a/Sources/ComposableNavigator/Navigator/NavigatorKeys.swift
+++ b/Sources/ComposableNavigator/Navigator/NavigatorKeys.swift
@@ -4,10 +4,18 @@ public enum NavigatorKey: EnvironmentKey {
   public static let defaultValue: Navigator = .stub()
 }
 
+public enum TreatSheetDismissAsAppearInPresenterKey: EnvironmentKey {
+  public static let defaultValue: Bool = false
+}
 
 public extension EnvironmentValues {
   var navigator: Navigator {
     get { self[NavigatorKey.self] }
     set { self[NavigatorKey.self] = newValue }
+  }
+  
+  var treatSheetDismissAsAppearInPresenter: Bool {
+    get { self[TreatSheetDismissAsAppearInPresenterKey.self] }
+    set { self[TreatSheetDismissAsAppearInPresenterKey.self] = newValue }
   }
 }

--- a/Sources/ComposableNavigator/PathBuilder/Routed.swift
+++ b/Sources/ComposableNavigator/PathBuilder/Routed.swift
@@ -3,6 +3,7 @@ import SwiftUI
 public struct Routed<Content: View, Next: View>: View {
   @Environment(\.currentScreenID) var screenID
   @Environment(\.navigator) var navigator
+  @Environment(\.treatSheetDismissAsAppearInPresenter) var treatSheetDismissAsAppearInPresenter
   @EnvironmentObject var dataSource: Navigator.Datasource
 
   private struct Successors: Identifiable {
@@ -48,7 +49,7 @@ public struct Routed<Content: View, Next: View>: View {
           label: { EmptyView() }
         )
       )
-      .onAppear {
+      .uiKitOnAppear {
         if let screen = self.screen {
           self.onAppear(!screen.hasAppeared)
 
@@ -120,7 +121,7 @@ public struct Routed<Content: View, Next: View>: View {
         return successors
       },
       set: { value in
-        if value == nil { onAppear(false) }
+        if value == nil, treatSheetDismissAsAppearInPresenter { onAppear(false) }
 
         guard let successor = successors?.first else {
             return
@@ -135,6 +136,7 @@ public struct Routed<Content: View, Next: View>: View {
       .environment(\.parentScreenID, screenID)
       .environment(\.currentScreenID, successors.id)
       .environment(\.navigator, navigator)
+      .environment(\.treatSheetDismissAsAppearInPresenter, treatSheetDismissAsAppearInPresenter)
       .environmentObject(dataSource)
 
     switch successors.first.content.presentationStyle {


### PR DESCRIPTION
Unfortunately, onAppear is broken in SwiftUI iOS >14.
Therefore, we fallback to UIKit's viewDidAppear method in `Routed<Content>` to determine when a screen is shown.

[Apple Developer Forums Discussion](https://developer.apple.com/forums/thread/655338)