### PR TITLE
Introduce PathBuilders namespace and PathBuilder protocol

### DIFF
--- a/Docs/PathBuilders.md
+++ b/Docs/PathBuilders.md
@@ -3,7 +3,7 @@
 The screen path builder describes how a single screen is built.  The content closure is only called if the path element's content of type HomeScreen.
 
 ```swift
-PathBuilder.screen(
+PathBuilders.screen(
   HomeScreen.self,
   content: {
     HomeView(...)
@@ -16,9 +16,9 @@ The Home screen builder extracts `HomeScreen` instances from the routing path an
 
 ## AnyOf path builder
 ```swift
-.screen(
+PathBuilders.screen(
 //  ...
-    nesting: .anyOf(
+    nesting: Builders.anyOf(
         SettingsScreen.builder(...),
         DetailScreen.builder(...)
     )
@@ -41,7 +41,7 @@ Keep in mind, that the order of the listed path builders matters. The first path
 In some cases, you want to make sure that the user will never be able to reach certain parts of your application. For example, you might want to show a login screen as long the user hasn't logged in. For these cases, you can use a conditional path builders.
 
 ```swift
-.conditional(
+PathBuilders.conditional(
     either: HomeScreen.builder(store: homeStore),
     or: LoginScreen.builder(store: loginStore),
     basedOn: { user.isLoggedIn }
@@ -54,7 +54,7 @@ The example here would never built routing paths using the HomeScreen.nuilder if
 The ifLet path builder unwraps an optional value and provides it to the path builder defining closure. 
 
 ```swift
-.if(
+PathBuilders.if(
   let: { store.detailStore }, 
   then: { detailStore in 
     DetailScreen.builder(store: detailStore)
@@ -67,7 +67,7 @@ The ifLet path builder unwraps an optional value and provides it to the path bui
 The ifLet path builder unwraps a screen, if the path element matches the screen type, and provides it to the path builder defining closure. 
 
 ```swift
-.if(
+PathBuilders.if(
   screen: { (screen: DetailScreen) in
     DetailScreen.builder(store.detailStore(for: screen.id))
   },
@@ -81,14 +81,14 @@ Wildcard path builder replaces any screen with a predefined one. Based on the ex
 To mitigate this problem, you can combine a conditional path builder with a wildcard path builder:
 
 ```swift
-.conditional(
-    either: .wildcard(
+PathBuilders.conditional(
+    either: PathBuilders.wildcard(
         screen: HomeScreen(),
         pathBuilder: HomeScreen.builder(store: homeStore)
     ),
-    or: wildcard(
+    or: PathBuilders.wildcard(
         screen: LoginScreen(), 
-        loginScreen(store: loginStore)
+        pathBuilder: loginScreen(store: loginStore)
     ),
     basedOn: { user.isLoggedIn }
 )
@@ -107,22 +107,22 @@ As an applications routing tree grows, the number of possible routing paths incr
 // Option A: Global factory function
 func detailScreenBuilder(
   ... // dependencies
-) -> PathBuilder {
-  .screen(
+) -> some PathBuilder {
+  PathBuilders.screen(
     DetailScreen.self,
     ... // implementation of the detail path builder
   )
 }
 ```
 
-### Option B: Extending the PathBuilder type
+### Option B: Extending the PathBuilders type
 Extend the PathBuilder type with static convenience factory methods for each of your apps screen.
 ```swift
-extension PathBuilder {
+extension PathBuilders {
   static func detailScreenBuilder(
   ... // dependencies
-  ) -> PathBuilder {
-    .screen(
+  ) -> some PathBuilder {
+    PathBuilders.screen(
       DetailScreen.self,
       ... // implementation of the detail path builder
     )
@@ -136,8 +136,8 @@ Extend the screen type with static convenience factory methods.
 extension DetailScreen {
   static func builder(
   ... // dependencies
-  ) -> PathBuilder {
-    .screen(
+  ) -> some PathBuilder {
+    PathBuilders.screen(
       DetailScreen.self,
       ... // implementation of the detail path builder
     )

--- a/Example/Example/AppCore.swift
+++ b/Example/Example/AppCore.swift
@@ -98,46 +98,7 @@ func initializeApp() -> some View {
     environment: AppEnvironment(navigator: appNavigator)
   )
 
-  let pathBuilder: PathBuilder = .screen( // /home
-    onAppear: { _ in print("HomeView appeared") },
-    content: { (_: HomeScreen) in
-      HomeView(
-        store: appStore.scope(
-          state: \.home,
-          action: AppAction.home
-        )
-      )
-    },
-    nesting: .anyOf(
-      .screen( // detail?id=123
-        content: { (screen: DetailScreen) in
-          IfLetStore(
-            appStore.scope(
-              state: { state in
-                state.details.first(where: { $0.id == screen.detailID }) },
-              action: { action in AppAction.detail(id: screen.detailID, action) }
-            ),
-            then: { detailStore in
-              DetailView(
-                store: detailStore
-              )
-            }
-          )
-        },
-        nesting: .screen( // settings
-          content: { (screen: SettingsScreen) in
-            SettingsView(store: appStore.scope(state: \.settings, action: AppAction.settings))
-          }
-        )
-      ),
-      .screen( // settings
-        content: { (screen: SettingsScreen) in
-          SettingsView(store: appStore.scope(state: \.settings, action: AppAction.settings))
-        }
-      )
-    )
-  )
-
+  let pathBuilder = HomeScreen.builder(appStore: appStore)
   return Root(
     dataSource: dataSource,
     pathBuilder: pathBuilder

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Composable Navigator is based on the concept of path builder composition. It
 Let's look at an example navigator (using TCA):
 
 ```swift
-let appBuilder: PathBuilder = .screen(
+let appBuilder: PathBuilder = PathBuilders.screen(
   HomeScreen.self,
   content: {
     HomeView(
@@ -55,7 +55,7 @@ let appBuilder: PathBuilder = .screen(
       )
     )
   },
-  nesting: .anyOf(
+  nesting: PathBuilders.anyOf(
     DetailScreen.builder(store: detailStore),
     SettingsScreen.builder(store: settingsStore)
   )
@@ -76,7 +76,7 @@ All available path builders are documented [here](./Docs/PathBuilders.md).
 import ComposableNavigator
 import SwiftUI
 
-let appBuilder: PathBuilder = .screen(
+let appBuilder: PathBuilder = PathBuilders.screen(
   HomeScreen.self,
   content: { HomeView(...) },
   nesting: .anyOf(

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/Generated.PathBuilder+AnyOf.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/Generated.PathBuilder+AnyOf.swift
@@ -235,7 +235,7 @@ public enum EitherABCDEFGHIJ<A: View, B: View, C: View, D: View, E: View, F: Vie
   }
 }
 
-public extension PathBuilder {
+public extension PathBuilders {
   /***
    ```swift
    .screen(
@@ -276,13 +276,18 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View  
+    A,
+    B,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>
-  ) -> PathBuilder<EitherAB<A, B>> {
-    PathBuilder<EitherAB<A, B>>(
+    _ a: ABuilder,
+    _ b: BBuilder
+  ) -> _PathBuilder<EitherAB<A, B>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B
+  {
+    _PathBuilder<EitherAB<A, B>>(
       buildPath: { path -> EitherAB<A, B>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -336,15 +341,22 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View  
+    A,
+    B,
+    C,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>
-  ) -> PathBuilder<EitherABC<A, B, C>> {
-    PathBuilder<EitherABC<A, B, C>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder
+  ) -> _PathBuilder<EitherABC<A, B, C>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C
+  {
+    _PathBuilder<EitherABC<A, B, C>>(
       buildPath: { path -> EitherABC<A, B, C>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -401,17 +413,26 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View  
+    A,
+    B,
+    C,
+    D,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>
-  ) -> PathBuilder<EitherABCD<A, B, C, D>> {
-    PathBuilder<EitherABCD<A, B, C, D>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder
+  ) -> _PathBuilder<EitherABCD<A, B, C, D>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D
+  {
+    _PathBuilder<EitherABCD<A, B, C, D>>(
       buildPath: { path -> EitherABCD<A, B, C, D>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -471,19 +492,30 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View,
-    E: View  
+    A,
+    B,
+    C,
+    D,
+    E,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder,
+    EBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>,
-    _ e: PathBuilder<E>
-  ) -> PathBuilder<EitherABCDE<A, B, C, D, E>> {
-    PathBuilder<EitherABCDE<A, B, C, D, E>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder,
+    _ e: EBuilder
+  ) -> _PathBuilder<EitherABCDE<A, B, C, D, E>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D,
+        EBuilder.Content == E
+  {
+    _PathBuilder<EitherABCDE<A, B, C, D, E>>(
       buildPath: { path -> EitherABCDE<A, B, C, D, E>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -546,21 +578,34 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View,
-    E: View,
-    F: View  
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder,
+    EBuilder: PathBuilder,
+    FBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>,
-    _ e: PathBuilder<E>,
-    _ f: PathBuilder<F>
-  ) -> PathBuilder<EitherABCDEF<A, B, C, D, E, F>> {
-    PathBuilder<EitherABCDEF<A, B, C, D, E, F>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder,
+    _ e: EBuilder,
+    _ f: FBuilder
+  ) -> _PathBuilder<EitherABCDEF<A, B, C, D, E, F>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D,
+        EBuilder.Content == E,
+        FBuilder.Content == F
+  {
+    _PathBuilder<EitherABCDEF<A, B, C, D, E, F>>(
       buildPath: { path -> EitherABCDEF<A, B, C, D, E, F>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -626,23 +671,38 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View,
-    E: View,
-    F: View,
-    G: View  
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder,
+    EBuilder: PathBuilder,
+    FBuilder: PathBuilder,
+    GBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>,
-    _ e: PathBuilder<E>,
-    _ f: PathBuilder<F>,
-    _ g: PathBuilder<G>
-  ) -> PathBuilder<EitherABCDEFG<A, B, C, D, E, F, G>> {
-    PathBuilder<EitherABCDEFG<A, B, C, D, E, F, G>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder,
+    _ e: EBuilder,
+    _ f: FBuilder,
+    _ g: GBuilder
+  ) -> _PathBuilder<EitherABCDEFG<A, B, C, D, E, F, G>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D,
+        EBuilder.Content == E,
+        FBuilder.Content == F,
+        GBuilder.Content == G
+  {
+    _PathBuilder<EitherABCDEFG<A, B, C, D, E, F, G>>(
       buildPath: { path -> EitherABCDEFG<A, B, C, D, E, F, G>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -711,25 +771,42 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View,
-    E: View,
-    F: View,
-    G: View,
-    H: View  
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder,
+    EBuilder: PathBuilder,
+    FBuilder: PathBuilder,
+    GBuilder: PathBuilder,
+    HBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>,
-    _ e: PathBuilder<E>,
-    _ f: PathBuilder<F>,
-    _ g: PathBuilder<G>,
-    _ h: PathBuilder<H>
-  ) -> PathBuilder<EitherABCDEFGH<A, B, C, D, E, F, G, H>> {
-    PathBuilder<EitherABCDEFGH<A, B, C, D, E, F, G, H>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder,
+    _ e: EBuilder,
+    _ f: FBuilder,
+    _ g: GBuilder,
+    _ h: HBuilder
+  ) -> _PathBuilder<EitherABCDEFGH<A, B, C, D, E, F, G, H>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D,
+        EBuilder.Content == E,
+        FBuilder.Content == F,
+        GBuilder.Content == G,
+        HBuilder.Content == H
+  {
+    _PathBuilder<EitherABCDEFGH<A, B, C, D, E, F, G, H>>(
       buildPath: { path -> EitherABCDEFGH<A, B, C, D, E, F, G, H>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -801,27 +878,46 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View,
-    E: View,
-    F: View,
-    G: View,
-    H: View,
-    I: View  
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder,
+    EBuilder: PathBuilder,
+    FBuilder: PathBuilder,
+    GBuilder: PathBuilder,
+    HBuilder: PathBuilder,
+    IBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>,
-    _ e: PathBuilder<E>,
-    _ f: PathBuilder<F>,
-    _ g: PathBuilder<G>,
-    _ h: PathBuilder<H>,
-    _ i: PathBuilder<I>
-  ) -> PathBuilder<EitherABCDEFGHI<A, B, C, D, E, F, G, H, I>> {
-    PathBuilder<EitherABCDEFGHI<A, B, C, D, E, F, G, H, I>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder,
+    _ e: EBuilder,
+    _ f: FBuilder,
+    _ g: GBuilder,
+    _ h: HBuilder,
+    _ i: IBuilder
+  ) -> _PathBuilder<EitherABCDEFGHI<A, B, C, D, E, F, G, H, I>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D,
+        EBuilder.Content == E,
+        FBuilder.Content == F,
+        GBuilder.Content == G,
+        HBuilder.Content == H,
+        IBuilder.Content == I
+  {
+    _PathBuilder<EitherABCDEFGHI<A, B, C, D, E, F, G, H, I>>(
       buildPath: { path -> EitherABCDEFGHI<A, B, C, D, E, F, G, H, I>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)
@@ -896,29 +992,50 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-    A: View,
-    B: View,
-    C: View,
-    D: View,
-    E: View,
-    F: View,
-    G: View,
-    H: View,
-    I: View,
-    J: View  
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    J,
+    ABuilder: PathBuilder,
+    BBuilder: PathBuilder,
+    CBuilder: PathBuilder,
+    DBuilder: PathBuilder,
+    EBuilder: PathBuilder,
+    FBuilder: PathBuilder,
+    GBuilder: PathBuilder,
+    HBuilder: PathBuilder,
+    IBuilder: PathBuilder,
+    JBuilder: PathBuilder
   >(
-    _ a: PathBuilder<A>,
-    _ b: PathBuilder<B>,
-    _ c: PathBuilder<C>,
-    _ d: PathBuilder<D>,
-    _ e: PathBuilder<E>,
-    _ f: PathBuilder<F>,
-    _ g: PathBuilder<G>,
-    _ h: PathBuilder<H>,
-    _ i: PathBuilder<I>,
-    _ j: PathBuilder<J>
-  ) -> PathBuilder<EitherABCDEFGHIJ<A, B, C, D, E, F, G, H, I, J>> {
-    PathBuilder<EitherABCDEFGHIJ<A, B, C, D, E, F, G, H, I, J>>(
+    _ a: ABuilder,
+    _ b: BBuilder,
+    _ c: CBuilder,
+    _ d: DBuilder,
+    _ e: EBuilder,
+    _ f: FBuilder,
+    _ g: GBuilder,
+    _ h: HBuilder,
+    _ i: IBuilder,
+    _ j: JBuilder
+  ) -> _PathBuilder<EitherABCDEFGHIJ<A, B, C, D, E, F, G, H, I, J>>
+  where ABuilder.Content == A,
+        BBuilder.Content == B,
+        CBuilder.Content == C,
+        DBuilder.Content == D,
+        EBuilder.Content == E,
+        FBuilder.Content == F,
+        GBuilder.Content == G,
+        HBuilder.Content == H,
+        IBuilder.Content == I,
+        JBuilder.Content == J
+  {
+    _PathBuilder<EitherABCDEFGHIJ<A, B, C, D, E, F, G, H, I, J>>(
       buildPath: { path -> EitherABCDEFGHIJ<A, B, C, D, E, F, G, H, I, J>? in 
         if let aContent = a.build(path: path) {
           return .a(aContent)

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+AnyOf.swift.gyb
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+AnyOf.swift.gyb
@@ -28,7 +28,7 @@ public enum ${enumName}: View {
 }
 
 % end
-public extension PathBuilder {
+public extension PathBuilders {
 % for i in range(2, combineCount+1):
 %{
     # ABCD...
@@ -42,17 +42,23 @@ public extension PathBuilder {
     # A, B, C, D...
     genericTypeList = ", ".join(genericCharacters)
 
-    # A: View, B: View, ...
-    requirements = ",\n".join(map(lambda x: "    {0}: View".format(x), genericCharacters))
+    # A,\n B\n, ...
+    requirements = ",\n".join(map(lambda x: "    {0}".format(x), genericCharacters))
+
+    # ABuilder: PathBuilder, BBuilder: PathBuilder, ...
+    builderRequirements = ",\n".join(map(lambda x: "    {0}Builder: PathBuilder".format(x), genericCharacters))
 
     # Combined<A, B, C, D>
     enumName = "Either{0}<{1}>".format(genericCharacters, genericTypeList)
 
     # _ a: PathBuilder<A>,\n ...
-    parameters = ",\n".join(map(lambda x: "    _ {0}: PathBuilder<{1}>".format(x.lower(), x), genericCharacters))
+    parameters = ",\n".join(map(lambda x: "    _ {0}: {1}Builder".format(x.lower(), x), genericCharacters))
+
+    # ABuilder.Content == A
+    whereCondition = "where " + ",\n        ".join(map(lambda x: "{0}Builder.Content == {0}".format(x), genericCharacters))
 
     # PathBuilder<Either<A, B, C, D>>
-    combinedPathBuilderType = "PathBuilder<{0}>".format(enumName)
+    combinedPathBuilderType = "_PathBuilder<{0}>".format(enumName)
 }%
   /***
    ```swift
@@ -94,10 +100,13 @@ public extension PathBuilder {
    ```
   */
   static func anyOf<
-${requirements}  
+${requirements},
+${builderRequirements}
   >(
 ${parameters}
-  ) -> ${combinedPathBuilderType} {
+  ) -> ${combinedPathBuilderType}
+  ${whereCondition}
+  {
     ${combinedPathBuilderType}(
       buildPath: { path -> ${enumName}? in 
         if let aContent = a.build(path: path) {

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Empty.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Empty.swift
@@ -1,11 +1,11 @@
-public extension PathBuilder {
+public extension PathBuilders {
   /**
    The empty path builder does not build any screen and just returns nil for all screens.
 
    Only use .empty as a stub value.
   */
-  static var empty: PathBuilder<Never> {
-    PathBuilder<Never>(
+  static var empty: _PathBuilder<Never> {
+    _PathBuilder<Never>(
       buildPath: { _ in nil }
     )
   }

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Screen.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Screen.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public extension PathBuilder {
+public extension PathBuilders {
   /**
    Creates a path builder responsible for a single screen.
 
@@ -26,12 +26,17 @@ public extension PathBuilder {
      - nesting:
         Any path builder that can follow after this screen
    */
-  static func screen<S: Screen, Content: View, Successor: View>(
+  static func screen<
+    S: Screen,
+    Content: View,
+    SuccessorBuilder: PathBuilder,
+    Successor
+  >(
     onAppear: @escaping (Bool) -> Void = { _ in },
     @ViewBuilder content build: @escaping (S) -> Content,
-    nesting: PathBuilder<Successor>
-  ) -> PathBuilder<Routed<Content, Successor>> {
-    PathBuilder<Routed<Content, Successor>>(
+    nesting: SuccessorBuilder
+  ) -> _PathBuilder<Routed<Content, Successor>> where SuccessorBuilder.Content == Successor {
+    _PathBuilder<Routed<Content, Successor>>(
       buildPath: { (path: [IdentifiedScreen]) -> Routed<Content, Successor>? in
         guard let head = path.first, let unwrapped: S = head.content.unwrap() else {
           return nil
@@ -71,11 +76,11 @@ public extension PathBuilder {
   static func screen<S: Screen, Content: View>(
     onAppear: @escaping (Bool) -> Void = { _ in },
     @ViewBuilder content build: @escaping (S) -> Content
-  ) -> PathBuilder<Routed<Content, Never>> {
+  ) -> _PathBuilder<Routed<Content, Never>> {
     screen(
       onAppear: onAppear,
       content: build,
-      nesting: .empty
+      nesting: PathBuilders.empty
     )
   }
 
@@ -107,13 +112,18 @@ public extension PathBuilder {
       - nesting:
         Any path builder that can follow after this screen
    */
-  static func screen<S: Screen, Content: View, Successor: View>(
+  static func screen<
+    S: Screen,
+    Content: View,
+    SuccessorBuilder: PathBuilder,
+    Successor
+  >(
     _ type: S.Type,
     onAppear: @escaping (Bool) -> Void = { _ in },
     @ViewBuilder content build: @escaping () -> Content,
-    nesting: PathBuilder<Successor>
-  ) -> PathBuilder<Routed<Content, Successor>> {
-    PathBuilder<Routed<Content, Successor>>(
+    nesting: SuccessorBuilder
+  ) -> _PathBuilder<Routed<Content, Successor>> where SuccessorBuilder.Content == Successor {
+    _PathBuilder<Routed<Content, Successor>>(
       buildPath: { (path: [IdentifiedScreen]) -> Routed<Content, Successor>? in
         guard let head = path.first, head.content.is(S.self) else {
           return nil
@@ -157,12 +167,12 @@ public extension PathBuilder {
     _ type: S.Type,
     onAppear: @escaping (Bool) -> Void = { _ in },
     @ViewBuilder content build: @escaping () -> Content
-  ) -> PathBuilder<Routed<Content, Never>> {
+  ) -> _PathBuilder<Routed<Content, Never>> {
     screen(
       type,
       onAppear: onAppear,
       content: build,
-      nesting: .empty
+      nesting: PathBuilders.empty
     )
   }
 }

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Wildcard.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Wildcard.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-public extension PathBuilder {
+public extension PathBuilders {
   /**
    Wildcard path builders replace any screen with a predefined one.
 
@@ -33,11 +33,15 @@ public extension PathBuilder {
       - pathBuilder:
         The path builder used to build the altered path.
   */
-  static func wildcard<S: Screen, Content: View>(
+  static func wildcard<
+    S: Screen,
+    ContentBuilder: PathBuilder,
+    Content
+  >(
     screen: S,
-    pathBuilder: PathBuilder<Content>
-  ) -> PathBuilder<Content> {
-    PathBuilder<Content>(
+    pathBuilder: ContentBuilder
+  ) -> _PathBuilder<Content> where ContentBuilder.Content == Content {
+    _PathBuilder<Content>(
       buildPath: { path in
         guard let identifiedWildcard = path.first.map(
             { IdentifiedScreen(id: $0.id, content: screen.eraseToAnyScreen(), hasAppeared: $0.hasAppeared) }

--- a/Sources/ComposableNavigator/PathBuilder/_PathBuilder.swift
+++ b/Sources/ComposableNavigator/PathBuilder/_PathBuilder.swift
@@ -1,6 +1,11 @@
 import SwiftUI
 
-public struct PathBuilder<Content: View> {
+public protocol PathBuilder {
+  associatedtype Content: View
+  func build(path: [IdentifiedScreen]) -> Content?
+}
+
+public struct _PathBuilder<Content: View>: PathBuilder {
   private let _buildPath: ([IdentifiedScreen]) -> Content?
 
   public init(buildPath: @escaping ([IdentifiedScreen]) -> Content?) {
@@ -11,3 +16,5 @@ public struct PathBuilder<Content: View> {
     return _buildPath(path)
   }
 }
+
+public enum PathBuilders {}

--- a/Sources/ComposableNavigator/Root.swift
+++ b/Sources/ComposableNavigator/Root.swift
@@ -1,14 +1,14 @@
 import SwiftUI
 
-public struct Root<R: View>: View {
+public struct Root<Builder: PathBuilder>: View {
   @ObservedObject private var dataSource: Navigator.Datasource
   private let navigator: Navigator
-  private let pathBuilder: PathBuilder<R>
+  private let pathBuilder: Builder
 
   public init(
     dataSource: Navigator.Datasource,
     navigator: Navigator,
-    pathBuilder: PathBuilder<R>
+    pathBuilder: Builder
   ) {
     self.dataSource = dataSource
     self.navigator = navigator
@@ -35,7 +35,7 @@ public struct Root<R: View>: View {
 public extension Root {
   init(
     dataSource: Navigator.Datasource,
-    pathBuilder: PathBuilder<R>
+    pathBuilder: Builder
   ) {
     self.init(
       dataSource: dataSource,

--- a/Sources/ComposableNavigatorTCA/PathBuilder/PathBuilder+IfLetStore.swift
+++ b/Sources/ComposableNavigatorTCA/PathBuilder/PathBuilder+IfLetStore.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import ComposableNavigator
 import SwiftUI
 
-public extension PathBuilder {
+public extension PathBuilders {
   static func ifLetStore<
     State: Equatable,
     Action,
@@ -10,10 +10,10 @@ public extension PathBuilder {
     Else: View
   >(
     store: Store<State?, Action>,
-    then: @escaping (Store<State, Action>) -> PathBuilder<If>,
-    else: PathBuilder<Else>
-  ) -> PathBuilder<EitherAB<If, Else>> {
-    PathBuilder<EitherAB<If, Else>>(
+    then: @escaping (Store<State, Action>) -> _PathBuilder<If>,
+    else: _PathBuilder<Else>
+  ) -> _PathBuilder<EitherAB<If, Else>> {
+    _PathBuilder<EitherAB<If, Else>>(
       buildPath: { path -> EitherAB<If, Else>? in
         if let state = ViewStore(store).state {
           return then(store.scope(state: { $0 ?? state })).build(path: path).flatMap(EitherAB.a)
@@ -30,9 +30,9 @@ public extension PathBuilder {
     If: View
   >(
     store: Store<State?, Action>,
-    then: @escaping (Store<State, Action>) -> PathBuilder<If>
-  ) -> PathBuilder<If> {
-    PathBuilder<If>(
+    then: @escaping (Store<State, Action>) -> _PathBuilder<If>
+  ) -> _PathBuilder<If> {
+    _PathBuilder<If>(
       buildPath: { path -> If? in
         if let state = ViewStore(store).state {
           return then(store.scope(state: { $0 ?? state })).build(path: path)


### PR DESCRIPTION
As the avoiding erasing to AnyView lead to PathBuilder being a generic struct, we would have to define the <Content: View> for returns which can be tedious.

Instead, we'll leverage opaque result types and use the `some` keyword in factory functions returning PathBuilders.

Had to introduce the PathBuilders namespace enum, as static members cannot be used on protocol metatypes. :(

**Check out this example regarding this issue** 🔝
```swift
protocol Builder {
  associatedtype Content
  func build() -> Content
}

struct B<Content>: Builder {
  let _build: () -> Content

  func build() -> Content {
    _build()
  }
}

extension Builder {
  static func builder() -> some Builder {
    B(_build: {1})
  }
}

let f = { Builder.builder() }
```

Comes with the drawback, that we now have to type PathBuilders.screen etc. whenever we want to instantiate a particular path builder, but that's better than erasing to AnyView.