### PR TITLE
Adds beforeBuild helper

### DIFF
--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilders+BeforeBuild.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilders+BeforeBuild.swift
@@ -1,4 +1,5 @@
 public extension PathBuilder {
+    /// Performs an action before this path builder is built.
     func beforeBuild(perform action: @escaping () -> Void) -> _PathBuilder<Content> {
         _PathBuilder(
             buildPath: { path in


### PR DESCRIPTION
Swift complains about not being able to infer complex return types when actions are performed as part of PathBuilder build closures.

Example
```swift
PathBuilders.if { (screen: Screen) in 
   print("Hello")
   return PathBuilders.empty
}
```
fails to build, but
```swift
PathBuilders.if { (screen: Screen) in 
   return PathBuilders.empty
}
```
succeeds.

The beforeBuild helper allows you to perform actions (like sending actions into a ViewStore) everytime a path is built. 

```swift
PathBuilders.if { (screen: Screen) in 
   return PathBuilders.empty.beforeBuild { print("Hello") }
}
```