### PR TITLE
Add replace(screen:, with:) and replaceContent(of:, with:)

### DIFF
--- a/Example/Example/Settings Screen/SettingsView.swift
+++ b/Example/Example/Settings Screen/SettingsView.swift
@@ -70,7 +70,7 @@ struct SettingsView: View {
               on: id
             )
           },
-          label: { Text("Go to [home/detail?id={id}/settings/shortcuts?style=push]") }
+          label: { Text("Go to [./shortcuts?style=push]") }
         )
 
         Button(
@@ -82,7 +82,7 @@ struct SettingsView: View {
               on: id
             )
           },
-          label: { Text("Go to [home/detail?id={id}/settings/shortcuts?style=sheet]") }
+          label: { Text("Go to [./shortcuts?style=sheet]") }
         )
 
         NavigationShortcuts()

--- a/Sources/ComposableNavigator/Navigator/Navigator+Testing.swift
+++ b/Sources/ComposableNavigator/Navigator/Navigator+Testing.swift
@@ -37,6 +37,12 @@ public extension Navigator {
     dismissSuccessorOfScreen: @escaping (AnyScreen) -> Void = { _ in
       fatalError("dismissSuccessor(of:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
     },
+    replaceContent: @escaping (ScreenID, AnyScreen) -> Void = { _, _ in
+        fatalError("replaceContent(of id:, with:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
+    },
+    replaceScreen: @escaping (AnyScreen, AnyScreen) -> Void = { _, _ in
+      fatalError("replace(screen:, with:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
+    },
     didAppear: @escaping (ScreenID) -> Void = { _ in
       fatalError("didAppear(id:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
     }
@@ -54,6 +60,8 @@ public extension Navigator {
       dismissScreen: dismissScreen,
       dismissSuccessor: dismissSuccessor,
       dismissSuccessorOfScreen: dismissSuccessorOfScreen,
+      replaceContent: replaceContent,
+      replaceScreen: replaceScreen,
       didAppear: didAppear
     )
   }
@@ -79,6 +87,12 @@ public extension Navigator {
     },
     dismissSuccessorInvoked: @escaping (Navigator.DismissSuccessorInvocation) -> Void = { _ in
       fatalError("dismissSuccessor(of:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
+    },
+    replaceContentInvoked: @escaping (Navigator.ReplaceContentInvocation) -> Void = { _ in
+        fatalError("replaceContent(of id:, with:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
+    },
+    replaceScreenInvoked: @escaping (Navigator.ReplaceScreenInvocation) -> Void = { _ in
+      fatalError("replace(screen:, with:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
     },
     didAppearInvoked: @escaping (Navigator.DidAppearInvocation) -> Void = { _ in
       fatalError("didAppear(id:) unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
@@ -118,6 +132,12 @@ public extension Navigator {
       },
       dismissSuccessorOfScreen: { screen in
         dismissSuccessorInvoked(Navigator.DismissSuccessorInvocation(identifier: .screen(screen)))
+      },
+      replaceContent: { id, newContent in
+        replaceContentInvoked(Navigator.ReplaceContentInvocation(id: id, newContent: newContent))
+      },
+      replaceScreen: { oldContent, newContent in
+        replaceScreenInvoked(Navigator.ReplaceScreenInvocation(oldContent: oldContent, newContent: newContent))
       },
       didAppear: { id in
         didAppearInvoked(Navigator.DidAppearInvocation(id: id))
@@ -276,6 +296,62 @@ public extension Navigator {
   ///  XCTAssertEqual(expectectedInvocations, invocations)
   ///```
   typealias DismissSuccessorInvocation = DismissInvocation
+
+  /// Testing helper
+  ///
+  /// # Example
+  /// ```swift
+  ///  var invocations = [Navigator.ReplaceScreenInvocation]()
+  ///  let expectectedInvocations = [
+  ///    Navigator.ReplaceScreenInvocation(
+  ///     oldContent: oldContent.eraseToAnyScreen(),
+  ///     newContent: expectedContent.eraseToAnyScreen()
+  ///    )
+  ///  ]
+  ///
+  ///  let sut = Navigator.mock(
+  ///    path: { self.path },
+  ///    didAppear: { id in
+  ///      invocations.append(.init(id: id))
+  ///    }
+  ///  )
+  ///
+  ///  sut.replace(screen: oldContent, with: expectedContent) // invoke code that invokes dismissSuccessor(of:)
+  ///
+  ///  XCTAssertEqual(expectectedInvocations, invocations)
+  ///```
+  struct ReplaceScreenInvocation: Hashable {
+    let oldContent: AnyScreen
+    let newContent: AnyScreen
+  }
+
+  /// Testing helper
+  ///
+  /// # Example
+  /// ```swift
+  ///  var invocations = [Navigator.ReplaceContentInvocation]()
+  ///  let expectectedInvocations = [
+  ///    Navigator.ReplaceContentInvocation(
+  ///     id: expectedID,
+  ///     newContent: expectedContent.eraseToAnyScreen()
+  ///    )
+  ///  ]
+  ///
+  ///  let sut = Navigator.mock(
+  ///    path: { self.path },
+  ///    didAppear: { id in
+  ///      invocations.append(.init(id: id))
+  ///    }
+  ///  )
+  ///
+  ///  sut.didAppear(id: expectedID) // invoke code that invokes dismissSuccessor(of:)
+  ///
+  ///  XCTAssertEqual(expectectedInvocations, invocations)
+  ///```
+  struct ReplaceContentInvocation: Hashable {
+    let id: ScreenID
+    let newContent: AnyScreen
+  }
 
   /// Testing helper
   ///

--- a/Sources/ComposableNavigator/Navigator/NavigatorDataSource+Navigator.swift
+++ b/Sources/ComposableNavigator/Navigator/NavigatorDataSource+Navigator.swift
@@ -38,6 +38,12 @@ public extension Navigator {
       dismissSuccessorOfScreen: { screen in
         dataSource.dismissSuccessor(of: screen)
       },
+      replaceContent: { id, newContent in
+        dataSource.replaceContent(of: id, with: newContent)
+      },
+      replaceScreen: { oldContent, newContent in
+        dataSource.replace(screen: oldContent, with: newContent)
+      },
       didAppear: { id in
         dataSource.didAppear(id: id)
       }

--- a/Sources/ComposableNavigator/Navigator/NavigatorDatasource.swift
+++ b/Sources/ComposableNavigator/Navigator/NavigatorDatasource.swift
@@ -135,15 +135,37 @@ public extension Navigator {
       path = Array(path.prefix(through: index))
     }
 
-    func didAppear(id: ScreenID) {
-      path = path.map { pathElement in
-        guard pathElement.id == id else { return pathElement }
-        return IdentifiedScreen(
-          id: pathElement.id,
-          content: pathElement.content,
-          hasAppeared: true
-        )
+    func replaceContent(of id: ScreenID, with newContent: AnyScreen) -> Void {
+      guard let index = path.firstIndex(where: { screen in screen.id == id }),
+            path[index].content != newContent else {
+        return
       }
+
+      path[index] = IdentifiedScreen(
+        id: id,
+        content: newContent,
+        hasAppeared: path[index].hasAppeared
+      )
+    }
+
+    func replace(screen: AnyScreen, with newContent: AnyScreen) -> Void {
+      guard let id = identifiedScreen(for: screen)?.id else {
+        return
+      }
+
+      replaceContent(of: id, with: newContent)
+    }
+
+    func didAppear(id: ScreenID) {
+      guard let index = path.firstIndex(where: { $0.id == id }) else {
+        return
+      }
+
+      path[index] = IdentifiedScreen(
+        id: id,
+        content: path[index].content,
+        hasAppeared: true
+      )
     }
   }
 }

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Screen.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Screen.swift
@@ -41,7 +41,6 @@ public extension PathBuilders {
         }
 
         return Routed(
-          wrapping: head.content,
           content: build(unwrapped),
           onAppear: onAppear,
           next: nesting.build(path:)
@@ -126,7 +125,6 @@ public extension PathBuilders {
         }
 
         return Routed(
-          wrapping: head.content,
           content: build(),
           onAppear: onAppear,
           next: nesting.build(path:)

--- a/Sources/ComposableNavigator/PathBuilder/Routed.swift
+++ b/Sources/ComposableNavigator/PathBuilder/Routed.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Screen container view, taking care of push and sheet bindings.
 public struct Routed<Content: View, Next: View>: View {
   @Environment(\.currentScreenID) var screenID
+  @Environment(\.currentScreen) var currentScreen
   @Environment(\.navigator) var navigator
   @Environment(\.treatSheetDismissAsAppearInPresenter) var treatSheetDismissAsAppearInPresenter
   @EnvironmentObject var dataSource: Navigator.Datasource
@@ -23,18 +24,15 @@ public struct Routed<Content: View, Next: View>: View {
     var id: ScreenID { first.id }
   }
 
-  private let currentScreen: AnyScreen
   private let content: Content
   private let onAppear: (Bool) -> Void
   private let next: (([IdentifiedScreen]) -> Next?)?
 
   public init(
-    wrapping: AnyScreen,
     content: Content,
     onAppear: @escaping (Bool) -> Void,
     next: (([IdentifiedScreen]) -> Next?)?
   ) {
-    self.currentScreen = wrapping
     self.content = content
     self.onAppear = onAppear
     self.next = next
@@ -42,7 +40,6 @@ public struct Routed<Content: View, Next: View>: View {
 
   public var body: some View {
     content
-      .environment(\.currentScreen, currentScreen)
       .sheet(
         item: sheetBinding,
         content: build(successors:)
@@ -146,7 +143,8 @@ public struct Routed<Content: View, Next: View>: View {
     let content = next?(successors.path)
       .environment(\.parentScreenID, screenID)
       .environment(\.parentScreen, currentScreen)
-      .environment(\.currentScreenID, successors.id)
+      .environment(\.currentScreenID, successors.first.id)
+      .environment(\.currentScreen, successors.first.content)
       .environment(\.navigator, navigator)
       .environment(\.treatSheetDismissAsAppearInPresenter, treatSheetDismissAsAppearInPresenter)
       .environmentObject(dataSource)

--- a/Sources/ComposableNavigator/Root.swift
+++ b/Sources/ComposableNavigator/Root.swift
@@ -55,6 +55,10 @@ public struct Root<Builder: PathBuilder>: View {
       dataSource.path.first?.id ?? .root
     )
     .environment(
+      \.currentScreen,
+      dataSource.path.first?.content ?? CurrentScreenKey.defaultValue
+    )
+    .environment(
       \.navigator,
       navigator
     )

--- a/Sources/ComposableNavigator/Screen/AnyScreen.swift
+++ b/Sources/ComposableNavigator/Screen/AnyScreen.swift
@@ -1,7 +1,7 @@
 /// Type-erased representation of `Screen` objects
-public struct AnyScreen: Hashable {
+public struct AnyScreen: Hashable, Screen {
   let screen: AnyHashable
-  let presentationStyle: ScreenPresentationStyle
+  public let presentationStyle: ScreenPresentationStyle
 
   public init<S: Screen>(_ route: S) {
     self.screen = route

--- a/Sources/ComposableNavigator/Screen/Screen.swift
+++ b/Sources/ComposableNavigator/Screen/Screen.swift
@@ -6,6 +6,11 @@ public protocol Screen: Hashable {
 public extension Screen {
   /// Erase an instance of a concrete Screen type to AnyScreen
   func eraseToAnyScreen() -> AnyScreen {
-    AnyScreen(self)
+    // If the screen was already type-erased, return the type-erased instance instead of wrapping it
+    if let anyScreen = self as? AnyScreen {
+        return anyScreen
+    } else {
+        return AnyScreen(self)
+    }
   }
 }

--- a/Sources/ComposableNavigator/Screen/ScreenKeys.swift
+++ b/Sources/ComposableNavigator/Screen/ScreenKeys.swift
@@ -38,11 +38,10 @@ enum CurrentScreenKey: EnvironmentKey {
   ///
   /// - SeeAlso: `Root.swift`
   static var defaultValue: AnyScreen {
-    struct DummyScreen: Screen {
+    struct UnbuildableScreen: Screen {
       let presentationStyle: ScreenPresentationStyle = .push
     }
-    print("\\.currentScreen not set. Make sure to wrap your application in a Root view or inject a screen via .environment(\\.currentScreen, screen.eraseToAnyScreen()) for testing purposes.")
-    return DummyScreen().eraseToAnyScreen()
+    return UnbuildableScreen().eraseToAnyScreen()
   }
 }
 

--- a/Tests/ComposableNavigatorTests/NavigatorDatasourceTests.swift
+++ b/Tests/ComposableNavigatorTests/NavigatorDatasourceTests.swift
@@ -851,6 +851,133 @@ final class NavigatorDatasourceTests: XCTestCase {
     )
   }
 
+  // MARK: - replaceContent(of:, with:)
+  func test_replaceContent_of_existent_id_with_newContent() {
+    let first = ScreenID()
+    let second = ScreenID()
+
+    let expectedContent = TestScreen(
+      identifier: "newContent",
+      presentationStyle: .push
+    ).eraseToAnyScreen()
+
+    let expectedPath = [
+      IdentifiedScreen(id: .root, content: expectedContent, hasAppeared: false),
+      IdentifiedScreen(id: first, content: next, hasAppeared: false),
+      IdentifiedScreen(id: second, content: root, hasAppeared: false)
+    ]
+
+    let sut = Navigator.Datasource(
+      path: [
+        IdentifiedScreen(id: .root, content: root, hasAppeared: false),
+        IdentifiedScreen(id: first, content: next, hasAppeared: false),
+        IdentifiedScreen(id: second, content: root, hasAppeared: false)
+      ],
+      screenID: { fatalError("unimplemented") }
+    )
+
+    sut.replaceContent(of: .root, with: expectedContent)
+
+    XCTAssertEqual(
+      sut.path,
+      expectedPath
+    )
+  }
+
+  func test_replaceContent_of_non_existent_screen_with_newContent() {
+    let first = ScreenID()
+    let second = ScreenID()
+    let third = ScreenID()
+
+    let expectedContent = TestScreen(
+      identifier: "newContent",
+      presentationStyle: .push
+    ).eraseToAnyScreen()
+
+    let expectedPath = [
+      IdentifiedScreen(id: .root, content: root, hasAppeared: false),
+      IdentifiedScreen(id: first, content: next, hasAppeared: false),
+      IdentifiedScreen(id: second, content: root, hasAppeared: false)
+    ]
+
+    let sut = Navigator.Datasource(
+      path: expectedPath,
+      screenID: { fatalError("unimplemented") }
+    )
+
+    sut.replaceContent(of: third, with: expectedContent)
+
+    XCTAssertEqual(
+      sut.path,
+      expectedPath
+    )
+  }
+
+  // MARK: - replace(screen:, with:)
+  func test_replace_existent_screen_with_newContent() {
+    let first = ScreenID()
+    let second = ScreenID()
+
+    let expectedContent = TestScreen(
+      identifier: "newContent",
+      presentationStyle: .push
+    ).eraseToAnyScreen()
+
+    let expectedPath = [
+      IdentifiedScreen(id: .root, content: root, hasAppeared: false),
+      IdentifiedScreen(id: first, content: next, hasAppeared: false),
+      IdentifiedScreen(id: second, content: expectedContent, hasAppeared: false)
+    ]
+
+    let sut = Navigator.Datasource(
+      path: [
+        IdentifiedScreen(id: .root, content: root, hasAppeared: false),
+        IdentifiedScreen(id: first, content: next, hasAppeared: false),
+        IdentifiedScreen(id: second, content: root, hasAppeared: false)
+      ],
+      screenID: { fatalError("unimplemented") }
+    )
+
+    sut.replace(screen: root.eraseToAnyScreen(), with: expectedContent)
+
+    XCTAssertEqual(
+      sut.path,
+      expectedPath
+    )
+  }
+
+  func test_replace_non_existent_screen_with_newContent() {
+    let first = ScreenID()
+    let second = ScreenID()
+    let nonExistent = TestScreen(
+      identifier: "non-existent",
+      presentationStyle: .push
+    ).eraseToAnyScreen()
+
+    let expectedContent = TestScreen(
+      identifier: "newContent",
+      presentationStyle: .push
+    ).eraseToAnyScreen()
+
+    let expectedPath = [
+      IdentifiedScreen(id: .root, content: root, hasAppeared: false),
+      IdentifiedScreen(id: first, content: next, hasAppeared: false),
+      IdentifiedScreen(id: second, content: root, hasAppeared: false)
+    ]
+
+    let sut = Navigator.Datasource(
+      path: expectedPath,
+      screenID: { fatalError("unimplemented") }
+    )
+
+    sut.replace(screen: nonExistent, with: expectedContent)
+    
+    XCTAssertEqual(
+      sut.path,
+      expectedPath
+    )
+  }
+  
   // MARK: - didAppear(id:)
   func test_didAppear() {
     let first = ScreenID()


### PR DESCRIPTION
Resolves #27 

Steps taken:
* Make AnyScreen conform to Screen protocol
* Do not type erase screens if they already type erased (i.e. do not wrap an AnyScreen in another AnyScreen)
* Remove all function calls that took AnyScreen from Navigator as AnyScreen is now a Screen
* Add `replace(screen:, with:)` and `replaceContent(of id:, with:)`
* Adjust the wildcard PathBuilder to build a WildcardView decorator that replaces the path element it replaced with the wildcard, when it appears.