### PR TITLE
Allow erasing circular paths

### DIFF
--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+EraseCircularPath.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+EraseCircularPath.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+/// An erased path builder that erases the underlying Content to AnyView
+public struct AnyPathBuilder: PathBuilder {
+  private let buildPathElement: (AnyScreen) -> AnyView?
+
+  /// Erases the passed PathBuilder's Content to AnyView, if it builds the passed PathElement
+  public init<Erased: PathBuilder>(erasing: Erased) {
+    buildPathElement = { pathElement in
+      erasing
+        .build(pathElement: pathElement)
+        .flatMap(AnyView.init)
+    }
+  }
+
+  public func build(pathElement: AnyScreen) -> AnyView? {
+    buildPathElement(pathElement)
+  }
+}
+
+extension PathBuilder {
+  /// Erases circular navigation paths
+  ///
+  /// NavigationTrees define a `PathBuilder<Content: View>` via their builder computed variable.
+  /// The `Screen` PathBuilder adds `NavigationNode<ScreenView, Successor>`s to the NavigationTree.
+  ///
+  /// One the one hand, this makes sure that all valid navigation paths are known at build time.
+  /// On the other hand, this leads to problems if the NavigationTree contains a circular path.
+  ///
+  /// The following NavigationTree leads to a circular path:
+  ///
+  /// ```swift
+  /// struct HomeScreen {
+  ///   let presentationStyle = ScreenPresentationStyle.push
+  ///
+  ///   struct Builder: NavigationTree {
+  ///     var builder: _PathBuilder<
+  ///       NavigationNode<HomeView,
+  ///           NavigationNode<HomeView, ...> // <- Circular Type
+  ///         >
+  ///     > {
+  ///       Screen(
+  ///         HomeScreen.self,
+  ///         content: HomeView.init,
+  ///         nesting: {
+  ///           HomeScreen.Builder()
+  ///         }
+  ///       )
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  ///
+  /// Whenever a `Screen` Builder is contained multiple times in a navigation tree,
+  /// the `Screen` and its successors are contained recursively in the NavigationTrees content type.
+  ///
+  /// Unfortunately, the compiler is not able to resolve recursive, generic types.
+  /// To solve this, we can erase PathBuilders that lead to circular paths.
+  ///
+  /// ```swift
+  /// struct HomeScreen {
+  ///   let presentationStyle = ScreenPresentationStyle.push
+  ///
+  ///   struct Builder: NavigationTree {
+  ///     var builder: _PathBuilder<
+  ///       NavigationNode<HomeView, AnyView> // <- No longer circular
+  ///     > {
+  ///       Screen(
+  ///         HomeScreen.self,
+  ///         content: HomeView.init,
+  ///         nesting: {
+  ///           HomeScreen
+  ///             .Builder()
+  ///             .eraseCircularNavigationPath()
+  ///         }
+  ///       )
+  ///     }
+  ///   }
+  /// }
+  /// ```
+  public func eraseCircularNavigationPath() -> AnyPathBuilder {
+    AnyPathBuilder(erasing: self)
+  }
+}

--- a/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+EraseCircularPathTests.swift
+++ b/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+EraseCircularPathTests.swift
@@ -1,0 +1,42 @@
+import ComposableNavigator
+import SwiftUI
+import XCTest
+
+final class PathBuilder_EraseCircularPathTests: XCTestCase {
+  struct CircularNavigationTree: NavigationTree {
+    var builder: some PathBuilder {
+      Screen(
+        TestScreen.self,
+        content: { EmptyView() },
+        nesting: { CircularNavigationTree().eraseCircularNavigationPath() }
+      )
+    }
+  }
+
+  func test_if_wrapped_builds_path_erases_to_AnyView() {
+    let sut = CircularNavigationTree().eraseCircularNavigationPath()
+
+    let built = sut.build(
+      pathElement: TestScreen(
+        identifier: "",
+        presentationStyle: .push
+      )
+    )
+
+    XCTAssertNotNil(built)
+  }
+
+  func test_if_wrapped_does_not_build_path_returns_nil() {
+    let sut = _PathBuilder<Never> { _ in nil }
+      .eraseCircularNavigationPath()
+
+    let built = sut.build(
+      pathElement: TestScreen(
+        identifier: "",
+        presentationStyle: .push
+      )
+    )
+
+    XCTAssertNil(built)
+  }
+}


### PR DESCRIPTION
[//]: # (Link the resolved Github issue.)
Resolves #62.

## Problem
[//]: # (Explain why this pull request is necessary.)
As described in #62, circular navigation paths currently lead to failing builds as the compiler is not able to resolve recursive content types.

## Solution
[//]: # (Explain how you solved the problem.)
Allow erasing circular navigation paths to AnyView. This has a performance impact as SwiftUI will no longer be able to use the View type to perform its diffing for all erased successors. As circular paths are the exception and not the rule, I think this is fine for now.