### PR TITLE
Changes fetch-depth in test workflow to 0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Problem
[//]: # (Explain why this pull request is necessary.)
Danger fails on PRs from forks.

## Solution
[//]: # (Explain how you solved the problem.)
According to https://github.com/danger/danger/issues/1103, setting the fetch-depth to 0, i.e. fetching all branches and tags, should fix this.