### PR TITLE
Introduces NavigationPathElement

### DIFF
--- a/Example/ExampleUITests/Screens/Detail.swift
+++ b/Example/ExampleUITests/Screens/Detail.swift
@@ -4,13 +4,13 @@ class Detail: Base {
   let id: String
   lazy var accessibilityIdentifiers = AccessibilityIdentifier.DetailScreen(id: id)
 
-  lazy var shortcutsButton = app
-    .buttons[accessibilityIdentifiers.shortcuts]
-    .await()
+  var shortcutsButton: XCUIElement {
+    app.buttons[accessibilityIdentifiers.shortcuts].await()
+  }
 
-  lazy var settingsButton = app
-    .buttons[accessibilityIdentifiers.settings]
-    .await()
+  var settingsButton: XCUIElement {
+    app.buttons[accessibilityIdentifiers.settings].await()
+  }
 
   var shortcuts: NavigationShortcuts {
     NavigationShortcuts(accessibilityPrefix: "detail.\(id)", app: app)

--- a/Example/ExampleUITests/Screens/Home.swift
+++ b/Example/ExampleUITests/Screens/Home.swift
@@ -2,18 +2,16 @@
 import XCTest
 
 class Home: Base {
-  lazy var settingsButton = app
-    .buttons[AccessibilityIdentifier.HomeScreen.settingsNavigationBarItem]
-    .await()
+  var settingsButton: XCUIElement {
+    app.buttons[AccessibilityIdentifier.HomeScreen.settingsNavigationBarItem].await()
+  }
 
   func detail(for id: String) -> XCUIElement {
-    app.buttons[AccessibilityIdentifier.HomeScreen.detail(for: id)]
-      .await()
+    app.buttons[AccessibilityIdentifier.HomeScreen.detail(for: id)].await()
   }
 
   func detailSettings(for id: String) -> XCUIElement {
-    app.buttons[AccessibilityIdentifier.HomeScreen.detailSettings(for: id)]
-      .await()
+    app.buttons[AccessibilityIdentifier.HomeScreen.detailSettings(for: id)].await()
   }
 
   @discardableResult

--- a/Example/ExampleUITests/Screens/Settings.swift
+++ b/Example/ExampleUITests/Screens/Settings.swift
@@ -12,13 +12,13 @@ class Settings<Predecessor: Base>: Base {
     AccessibilityIdentifier.SettingsScreen(prefix: prefix)
   }
 
-  lazy var shortscutsSheetButton = app
-    .buttons[accessibilityIdentifiers.shortcutsSheet]
-    .await()
+  var shortcutsSheetButton: XCUIElement {
+    app.buttons[accessibilityIdentifiers.shortcutsSheet].await()
+  }
 
-  lazy var shortscutsPushButton = app
-    .buttons[accessibilityIdentifiers.shortcutsPush]
-    .await()
+  var shortcutsPushButton: XCUIElement {
+    app.buttons[accessibilityIdentifiers.shortcutsPush].await()
+  }
 
   init(predecessor: Predecessor, prefix: String, app: XCUIApplication) {
     self.predecessor = predecessor
@@ -28,19 +28,19 @@ class Settings<Predecessor: Base>: Base {
 
   @discardableResult
   func assertVisible() -> Self {
-    XCTAssertTrue(shortscutsSheetButton.exists)
+    XCTAssertTrue(shortcutsSheetButton.exists)
     return self
   }
 
   @discardableResult
   func goToShortcutsPush() -> NavigationShortcuts {
-    shortscutsPushButton.tap()
+    shortcutsPushButton.tap()
     return NavigationShortcuts(accessibilityPrefix: "shortcuts", app: app)
   }
 
   @discardableResult
   func goToShortcutsSheet() -> NavigationShortcuts {
-    shortscutsSheetButton.tap()
+    shortcutsSheetButton.tap()
     return NavigationShortcuts(accessibilityPrefix: "shortcuts", app: app)
   }
 

--- a/Example/ExampleUITests/Screens/XCUIElement+ExistsAfterTimeout.swift
+++ b/Example/ExampleUITests/Screens/XCUIElement+ExistsAfterTimeout.swift
@@ -2,8 +2,8 @@ import XCTest
 
 extension XCUIElement {
   func await(_ timeout: TimeInterval = 6.0) -> XCUIElement {
-    _ = exists(after: timeout, pollInterval: 0.2)
-    return self
+    let exists = self.exists(after: timeout, pollInterval: 0.2)
+    return exists ? self: self
   }
   
   func exists(after timeout: TimeInterval, pollInterval: TimeInterval) -> Bool {

--- a/Sources/ComposableNavigator/NavigationTree/NavigationTree.swift
+++ b/Sources/ComposableNavigator/NavigationTree/NavigationTree.swift
@@ -358,7 +358,7 @@ public protocol NavigationTree: PathBuilder {
 }
 
 extension NavigationTree {
-  public func build(pathElement: AnyScreen) -> Builder.Content? {
+  public func build(pathElement: NavigationPathElement) -> Builder.Content? {
     builder.build(pathElement: pathElement)
   }
 }

--- a/Sources/ComposableNavigator/Navigator/Navigator+Debug.swift
+++ b/Sources/ComposableNavigator/Navigator/Navigator+Debug.swift
@@ -3,7 +3,7 @@ public extension Navigator {
   /// Enable  logging received function calls and path changes.
   func debug(
     log: @escaping (String) -> Void = { print($0) },
-    dumpPath: @escaping (PathUpdate) -> Void = { dump($0) }
+    dumpPath: @escaping (NavigationPathUpdate) -> Void = { dump($0) }
   ) -> Navigator {
     Navigator(
       path: path,

--- a/Sources/ComposableNavigator/Navigator/Navigator+Testing.swift
+++ b/Sources/ComposableNavigator/Navigator/Navigator+Testing.swift
@@ -1,7 +1,7 @@
 // MARK: - Stub
 public extension Navigator {
   static func mock(
-    path: @escaping () -> PathUpdate = {
+    path: @escaping () -> NavigationPathUpdate = {
       fatalError("path() unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
     },
     go: @escaping (AnyScreen, ScreenID) -> Void = { _, _ in
@@ -67,7 +67,7 @@ public extension Navigator {
   }
 
   static func mock(
-    path: @escaping () -> PathUpdate = {
+    path: @escaping () -> NavigationPathUpdate = {
       fatalError("path() unimplemented in stub. Make sure to wrap your application in a Root view or inject Navigator via .environment(\\.navigator, navigator) for testing purposes.")
     },
     goToInvoked: @escaping (Navigator.GoToInvocation) -> Void = { _ in

--- a/Sources/ComposableNavigator/Navigator/Navigator.swift
+++ b/Sources/ComposableNavigator/Navigator/Navigator.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Facade type erasing the type of the underlying datasource
 public struct Navigator {
-  private let _path: () -> PathUpdate
+  private let _path: () -> NavigationPathUpdate
   private let _go: (AnyScreen, ScreenID) -> Void
   private let _goToOnScreen: (AnyScreen, AnyScreen) -> Void
   private let _goToPath: ([AnyScreen], ScreenID) -> Void
@@ -22,7 +22,7 @@ public struct Navigator {
   /// Retrieve the current value of the navigation path
   /// - Returns: The current navigation path
   /// - SeeAlso: `Navigator.debug()`
-  func path() -> PathUpdate {
+  func path() -> NavigationPathUpdate {
     _path()
   }
 
@@ -346,7 +346,7 @@ public struct Navigator {
   }
 
   public init(
-    path: @escaping () -> PathUpdate,
+    path: @escaping () -> NavigationPathUpdate,
     go: @escaping (AnyScreen, ScreenID) -> Void,
     goToOnScreen: @escaping (AnyScreen, AnyScreen) -> Void,
     goToPath: @escaping ([AnyScreen], ScreenID) -> Void,

--- a/Sources/ComposableNavigator/Navigator/Path/NavigationPath.swift
+++ b/Sources/ComposableNavigator/Navigator/Path/NavigationPath.swift
@@ -1,0 +1,1 @@
+public typealias NavigationPath = [NavigationPathElement]

--- a/Sources/ComposableNavigator/Navigator/Path/NavigationPathElementUpdate.swift
+++ b/Sources/ComposableNavigator/Navigator/Path/NavigationPathElementUpdate.swift
@@ -1,0 +1,9 @@
+public struct NavigationPathElementUpdate: Hashable {
+  public let previous: NavigationPathElement?
+  public let current: NavigationPathElement?
+
+  public init(previous: NavigationPathElement?, current: NavigationPathElement?) {
+    self.previous = previous
+    self.current = current
+  }
+}

--- a/Sources/ComposableNavigator/Navigator/Path/NavigationPathUpdate.swift
+++ b/Sources/ComposableNavigator/Navigator/Path/NavigationPathUpdate.swift
@@ -1,16 +1,16 @@
-public struct PathUpdate: Equatable {
-  public let previous: [IdentifiedScreen]
-  public let current: [IdentifiedScreen]
+public struct NavigationPathUpdate: Equatable {
+  public let previous: NavigationPath
+  public let current: NavigationPath
 
-  public func component(for id: ScreenID) -> PathComponentUpdate {
-    PathComponentUpdate(
+  public func component(for id: ScreenID) -> NavigationPathElementUpdate {
+    NavigationPathElementUpdate(
       previous: extractPathComponent(for: id, from: previous),
       current: extractPathComponent(for: id, from: current)
     )
   }
 
-  public func successor(of id: ScreenID) -> PathComponentUpdate {
-    PathComponentUpdate(
+  public func successor(of id: ScreenID) -> NavigationPathElementUpdate {
+    NavigationPathElementUpdate(
       previous: extractSuccessor(of: id, from: previous),
       current: extractSuccessor(of: id, from: current)
     )
@@ -18,15 +18,15 @@ public struct PathUpdate: Equatable {
 
   private func extractPathComponent(
     for id: ScreenID,
-    from path: [IdentifiedScreen]
-  ) -> IdentifiedScreen? {
+    from path: NavigationPath
+  ) -> NavigationPathElement? {
     return path.first(where: { $0.id == id })
   }
 
   private func extractSuccessor(
     of id: ScreenID,
-    from path: [IdentifiedScreen]
-  ) -> IdentifiedScreen? {
+    from path: NavigationPath
+  ) -> NavigationPathElement? {
     guard let successorIndex = path.firstIndex(where: { $0.id == id })?.advanced(by: 1),
           path.indices.contains(successorIndex)
     else {

--- a/Sources/ComposableNavigator/Navigator/Path/PathComponentUpdate.swift
+++ b/Sources/ComposableNavigator/Navigator/Path/PathComponentUpdate.swift
@@ -1,9 +1,0 @@
-public struct PathComponentUpdate: Hashable {
-  public let previous: IdentifiedScreen?
-  public let current: IdentifiedScreen?
-
-  public init(previous: IdentifiedScreen?, current: IdentifiedScreen?) {
-    self.previous = previous
-    self.current = current
-  }
-}

--- a/Sources/ComposableNavigator/Navigator/Path/PathElement/NavigationPathElement.swift
+++ b/Sources/ComposableNavigator/Navigator/Path/PathElement/NavigationPathElement.swift
@@ -1,0 +1,31 @@
+public enum NavigationPathElement: Hashable {
+  case screen(IdentifiedScreen)
+
+  public var id: ScreenID {
+    switch self {
+    case .screen(let screen):
+      return screen.id
+    }
+  }
+
+  public func ids() -> Set<ScreenID> {
+    switch self {
+    case .screen(let screen):
+      return [screen.id]
+    }
+  }
+
+  public var content: AnyScreen {
+    switch self {
+    case .screen(let screen):
+      return screen.content
+    }
+  }
+
+  public var hasAppeared: Bool {
+    switch self {
+    case .screen(let screen):
+      return screen.hasAppeared
+    }
+  }
+}

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Conditional.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Conditional.swift
@@ -141,8 +141,10 @@ public extension PathBuilders {
     else: Else
   ) -> _PathBuilder<EitherAB<If.Content, Else.Content>> {
     _PathBuilder { pathElement in
-      if let unwrappedScreen: S = pathElement.unwrap() {
-        return pathBuilder(unwrappedScreen).build(pathElement: pathElement).map(EitherAB.a)
+      if let unwrappedScreen: S = pathElement.content.unwrap() {
+        return pathBuilder(unwrappedScreen)
+          .build(pathElement: pathElement)
+          .map(EitherAB.a)
       } else {
         return `else`.build(pathElement: pathElement).map(EitherAB.b)
       }

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Empty.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Empty.swift
@@ -1,6 +1,6 @@
 public extension PathBuilders {
   struct EmptyBuilder: PathBuilder {
-    public func build(pathElement: AnyScreen) -> Never? { nil }
+    public func build(pathElement: NavigationPathElement) -> Never? { nil }
   }
 
   /// The empty `PathBuilder` does not build any screen and just returns nil for all screens.

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+EraseCircularPath.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+EraseCircularPath.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// An erased path builder that erases the underlying Content to AnyView
 public struct AnyPathBuilder: PathBuilder {
-  private let buildPathElement: (AnyScreen) -> AnyView?
+  private let buildPathElement: (NavigationPathElement) -> AnyView?
 
   /// Erases the passed PathBuilder's Content to AnyView, if it builds the passed PathElement
   public init<Erased: PathBuilder>(erasing: Erased) {
@@ -13,7 +13,7 @@ public struct AnyPathBuilder: PathBuilder {
     }
   }
 
-  public func build(pathElement: AnyScreen) -> AnyView? {
+  public func build(pathElement: NavigationPathElement) -> AnyView? {
     buildPathElement(pathElement)
   }
 }

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+OnDismiss.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+OnDismiss.swift
@@ -4,7 +4,7 @@ public struct OnDismissView<Content: View>: View {
   @EnvironmentObject var datasource: Navigator.Datasource
   @Environment(\.parentScreenID) var parentScreenID
 
-  let build: (AnyScreen) -> Content?
+  let build: (NavigationPathElement) -> Content?
   let content: Content
   let perform: (AnyScreen) -> Void
 
@@ -18,7 +18,7 @@ public struct OnDismissView<Content: View>: View {
           else { return }
 
           let update = path.successor(of: parentScreenID)
-          let built = update.current.flatMap { current in build(current.content) }
+          let built = update.current.flatMap(build)
           let previouslyBuiltScreen = update.previous?.content
           let builtScreen = built != nil ? update.current?.content : nil
 
@@ -54,7 +54,11 @@ public extension PathBuilder {
   ) -> _PathBuilder<OnDismissView<Content>> {
     _PathBuilder { pathElement in
       build(pathElement: pathElement).flatMap { content in
-        OnDismissView(build: self.build(pathElement:), content: content, perform: perform)
+        OnDismissView(
+            build: self.build(pathElement:),
+            content: content,
+            perform: perform
+        )
       }
     }
   }

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Screen.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Screen.swift
@@ -34,7 +34,8 @@ public extension PathBuilders {
     nesting: Successor
   ) -> _PathBuilder<NavigationNode<Content, Successor.Content>> {
     _PathBuilder { pathElement in
-      guard let unwrapped: S = pathElement.unwrap() else {
+      guard case let .screen(screen) = pathElement,
+            let unwrapped: S = screen.content.unwrap() else {
         return nil
       }
 
@@ -114,7 +115,7 @@ public extension PathBuilders {
     nesting: Successor
   ) -> _PathBuilder<NavigationNode<Content, Successor.Content>> {
     _PathBuilder { pathElement in
-      guard pathElement.is(S.self) else {
+      guard case .screen(let screen) = pathElement, screen.content.is(S.self) else {
         return nil
       }
 

--- a/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Wildcard.swift
+++ b/Sources/ComposableNavigator/PathBuilder/PathBuilders/PathBuilder+Wildcard.swift
@@ -57,13 +57,32 @@ public extension PathBuilders {
     pathBuilder: ContentBuilder
   ) -> _PathBuilder<WildcardView<Content, S>> where ContentBuilder.Content == Content {
     _PathBuilder { pathElement in
-      pathBuilder.build(pathElement: screen.eraseToAnyScreen())
-        .flatMap { content in
-          WildcardView(
-            wildcard: screen,
-            content: content
-          )
-        }
+      pathBuilder.build(
+        pathElement: pathElement.wildcard(
+          screen: screen
+        )
+      )
+      .flatMap { content in
+        WildcardView(
+          wildcard: screen,
+          content: content
+        )
+      }
+    }
+  }
+}
+
+extension NavigationPathElement {
+  func wildcard<S: Screen>(screen: S) -> NavigationPathElement {
+    switch self {
+    case .screen:
+      return .screen(
+        IdentifiedScreen(
+          id: id,
+          content: screen,
+          hasAppeared: hasAppeared
+        )
+      )
     }
   }
 }

--- a/Sources/ComposableNavigator/PathBuilder/_PathBuilder.swift
+++ b/Sources/ComposableNavigator/PathBuilder/_PathBuilder.swift
@@ -3,24 +3,18 @@ import SwiftUI
 /// PathBuilders define how a navigation path is built into a view hierarchy
 public protocol PathBuilder {
   associatedtype Content: View
-  func build(pathElement: AnyScreen) -> Content?
-}
-
-extension PathBuilder {
-  public func build<S: Screen>(pathElement: S) -> Content? {
-    self.build(pathElement: pathElement.eraseToAnyScreen())
-  }
+  func build(pathElement: NavigationPathElement) -> Content?
 }
 
 /// Convenience type to define PathBuilders based on a build closure
 public struct _PathBuilder<Content: View>: PathBuilder {
-  private let _buildPathElement: (AnyScreen) -> Content?
+  private let _buildPathElement: (NavigationPathElement) -> Content?
 
-  public init(_ buildPathElement: @escaping (AnyScreen) -> Content?) {
+  public init(_ buildPathElement: @escaping (NavigationPathElement) -> Content?) {
     self._buildPathElement = buildPathElement
   }
 
-  public func build(pathElement: AnyScreen) -> Content? {
+  public func build(pathElement: NavigationPathElement) -> Content? {
     return _buildPathElement(pathElement)
   }
 }

--- a/Sources/ComposableNavigator/Root.swift
+++ b/Sources/ComposableNavigator/Root.swift
@@ -60,7 +60,7 @@ public struct Root<Builder: PathBuilder>: View {
     if let rootPathComponent = dataSource.path.current.first {
       NavigationView {
         pathBuilder.build(
-          pathElement: rootPathComponent.content
+          pathElement: rootPathComponent
         )
       }
       .environment(

--- a/Tests/ComposableNavigatorTCATests/NavigationPathElementHelpers.swift
+++ b/Tests/ComposableNavigatorTCATests/NavigationPathElementHelpers.swift
@@ -1,0 +1,31 @@
+@testable import ComposableNavigator
+
+extension Screen {
+  func asPathElement(
+    with id: ScreenID = .root,
+    hasAppeared: Bool = false
+  ) -> NavigationPathElement {
+    .screen(
+      IdentifiedScreen(
+        id: id,
+        content: self,
+        hasAppeared: hasAppeared
+      )
+    )
+  }
+}
+
+extension IdentifiedScreen {
+  func asPathElement() -> NavigationPathElement {
+    .screen(self)
+  }
+}
+
+extension NavigationPathUpdate {
+  init(previous: [IdentifiedScreen], current: [IdentifiedScreen]) {
+    self.init(
+      previous: previous.map { $0.asPathElement() },
+      current: current.map { $0.asPathElement() }
+    )
+  }
+}

--- a/Tests/ComposableNavigatorTCATests/PathBuilder+IfLetStoreTests.swift
+++ b/Tests/ComposableNavigatorTCATests/PathBuilder+IfLetStoreTests.swift
@@ -15,7 +15,7 @@ final class PathBuilder_IfLetStoreTests: XCTestCase {
       environment: ()
     )
 
-    let expectedPath = TestScreen().eraseToAnyScreen()
+    let expectedPath = TestScreen().asPathElement()
 
     let sut = PathBuilders.ifLetStore(
       store: store,
@@ -42,7 +42,7 @@ final class PathBuilder_IfLetStoreTests: XCTestCase {
       environment: ()
     )
 
-    let expectedPath = TestScreen().eraseToAnyScreen()
+    let expectedPath = TestScreen().asPathElement()
 
     let sut = PathBuilders.ifLetStore(
       store: store,
@@ -66,16 +66,16 @@ final class PathBuilder_IfLetStoreTests: XCTestCase {
       environment: ()
     )
 
-    var thenBuilderInvocations = [AnyScreen]()
-    var elseBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
+    var elseBuilderInvocations = [NavigationPathElement]()
 
-    let expectedPath =  TestScreen().eraseToAnyScreen()
+    let expectedPath =  TestScreen().asPathElement()
 
     let expectedThenBuilderInvocations = [
       expectedPath
     ]
 
-    let expectedElseBuilderInvocations = [AnyScreen]()
+    let expectedElseBuilderInvocations = [NavigationPathElement]()
 
     let sut = PathBuilders.ifLetStore(
       store: store,
@@ -106,12 +106,12 @@ final class PathBuilder_IfLetStoreTests: XCTestCase {
       environment: ()
     )
 
-    var thenBuilderInvocations = [AnyScreen]()
-    var elseBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
+    var elseBuilderInvocations = [NavigationPathElement]()
 
-    let expectedPath = TestScreen().eraseToAnyScreen()
+    let expectedPath = TestScreen().asPathElement()
 
-    let expectedThenBuilderInvocations = [AnyScreen]()
+    let expectedThenBuilderInvocations = [NavigationPathElement]()
 
     let expectedElseBuilderInvocations = [
       expectedPath

--- a/Tests/ComposableNavigatorTCATests/PathBuilder+OnDismiss+TCATests.swift
+++ b/Tests/ComposableNavigatorTCATests/PathBuilder+OnDismiss+TCATests.swift
@@ -55,7 +55,7 @@ final class PathBuilder_OnDismiss_TCATests: XCTestCase {
       )
 
     let content = sut
-      .build(pathElement: dataSource.path.component(for: nextID).current!.content)?
+      .build(pathElement: dataSource.path.component(for: nextID).current!)?
       .environment(\.parentScreenID, .root)
       .environmentObject(dataSource)
       .frame(width: 20, height: 20)
@@ -95,7 +95,7 @@ final class PathBuilder_OnDismiss_TCATests: XCTestCase {
       )
 
     let content = sut
-      .build(pathElement: dataSource.path.component(for: nextID).current!.content)?
+      .build(pathElement: dataSource.path.component(for: nextID).current!)?
       .environment(\.parentScreenID, .root)
       .environmentObject(dataSource)
       .frame(width: 20, height: 20)
@@ -134,7 +134,7 @@ final class PathBuilder_OnDismiss_TCATests: XCTestCase {
       )
     
     let content = sut
-      .build(pathElement: dataSource.path.component(for: nextID).current!.content)?
+      .build(pathElement: dataSource.path.component(for: nextID).current!)?
       .environment(\.parentScreenID, .root)
       .environmentObject(dataSource)
       .frame(width: 20, height: 20)

--- a/Tests/ComposableNavigatorTests/Helpers/NavigationPathElementHelpers.swift
+++ b/Tests/ComposableNavigatorTests/Helpers/NavigationPathElementHelpers.swift
@@ -1,0 +1,31 @@
+@testable import ComposableNavigator
+
+extension Screen {
+  func asPathElement(
+    with id: ScreenID = .root,
+    hasAppeared: Bool = false
+  ) -> NavigationPathElement {
+    .screen(
+      IdentifiedScreen(
+        id: id,
+        content: self,
+        hasAppeared: hasAppeared
+      )
+    )
+  }
+}
+
+extension IdentifiedScreen {
+  func asPathElement() -> NavigationPathElement {
+    .screen(self)
+  }
+}
+
+extension NavigationPathUpdate {
+  init(previous: [IdentifiedScreen], current: [IdentifiedScreen]) {
+    self.init(
+      previous: previous.map { $0.asPathElement() },
+      current: current.map { $0.asPathElement() }
+    )
+  }
+}

--- a/Tests/ComposableNavigatorTests/NavigationTree/Generated.NavigationTreeBuilder+AnyOf.swift
+++ b/Tests/ComposableNavigatorTests/NavigationTree/Generated.NavigationTreeBuilder+AnyOf.swift
@@ -62,7 +62,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -77,7 +77,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -91,7 +91,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -113,7 +113,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -128,7 +128,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -143,7 +143,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -157,7 +157,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -183,7 +183,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -198,7 +198,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -213,7 +213,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -228,7 +228,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -242,7 +242,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -272,7 +272,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -287,7 +287,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -302,7 +302,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -317,7 +317,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -332,7 +332,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: eScreen
-    let eBuiltView = sut.build(pathElement: EScreen())
+    let eBuiltView = sut.build(pathElement: EScreen().asPathElement())
 
     guard case .e = eBuiltView else {
       XCTFail("Expected \(EScreen.self) to build Either.e. Got \(eBuiltView.debugDescription).")
@@ -346,7 +346,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -380,7 +380,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -395,7 +395,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -410,7 +410,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -425,7 +425,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -440,7 +440,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: eScreen
-    let eBuiltView = sut.build(pathElement: EScreen())
+    let eBuiltView = sut.build(pathElement: EScreen().asPathElement())
 
     guard case .e = eBuiltView else {
       XCTFail("Expected \(EScreen.self) to build Either.e. Got \(eBuiltView.debugDescription).")
@@ -455,7 +455,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: fScreen
-    let fBuiltView = sut.build(pathElement: FScreen())
+    let fBuiltView = sut.build(pathElement: FScreen().asPathElement())
 
     guard case .f = fBuiltView else {
       XCTFail("Expected \(FScreen.self) to build Either.f. Got \(fBuiltView.debugDescription).")
@@ -469,7 +469,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -507,7 +507,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -522,7 +522,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -537,7 +537,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -552,7 +552,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -567,7 +567,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: eScreen
-    let eBuiltView = sut.build(pathElement: EScreen())
+    let eBuiltView = sut.build(pathElement: EScreen().asPathElement())
 
     guard case .e = eBuiltView else {
       XCTFail("Expected \(EScreen.self) to build Either.e. Got \(eBuiltView.debugDescription).")
@@ -582,7 +582,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: fScreen
-    let fBuiltView = sut.build(pathElement: FScreen())
+    let fBuiltView = sut.build(pathElement: FScreen().asPathElement())
 
     guard case .f = fBuiltView else {
       XCTFail("Expected \(FScreen.self) to build Either.f. Got \(fBuiltView.debugDescription).")
@@ -597,7 +597,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: gScreen
-    let gBuiltView = sut.build(pathElement: GScreen())
+    let gBuiltView = sut.build(pathElement: GScreen().asPathElement())
 
     guard case .g = gBuiltView else {
       XCTFail("Expected \(GScreen.self) to build Either.g. Got \(gBuiltView.debugDescription).")
@@ -611,7 +611,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -653,7 +653,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -668,7 +668,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -683,7 +683,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -698,7 +698,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -713,7 +713,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: eScreen
-    let eBuiltView = sut.build(pathElement: EScreen())
+    let eBuiltView = sut.build(pathElement: EScreen().asPathElement())
 
     guard case .e = eBuiltView else {
       XCTFail("Expected \(EScreen.self) to build Either.e. Got \(eBuiltView.debugDescription).")
@@ -728,7 +728,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: fScreen
-    let fBuiltView = sut.build(pathElement: FScreen())
+    let fBuiltView = sut.build(pathElement: FScreen().asPathElement())
 
     guard case .f = fBuiltView else {
       XCTFail("Expected \(FScreen.self) to build Either.f. Got \(fBuiltView.debugDescription).")
@@ -743,7 +743,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: gScreen
-    let gBuiltView = sut.build(pathElement: GScreen())
+    let gBuiltView = sut.build(pathElement: GScreen().asPathElement())
 
     guard case .g = gBuiltView else {
       XCTFail("Expected \(GScreen.self) to build Either.g. Got \(gBuiltView.debugDescription).")
@@ -758,7 +758,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: hScreen
-    let hBuiltView = sut.build(pathElement: HScreen())
+    let hBuiltView = sut.build(pathElement: HScreen().asPathElement())
 
     guard case .h = hBuiltView else {
       XCTFail("Expected \(HScreen.self) to build Either.h. Got \(hBuiltView.debugDescription).")
@@ -772,7 +772,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -818,7 +818,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -833,7 +833,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -848,7 +848,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -863,7 +863,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -878,7 +878,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: eScreen
-    let eBuiltView = sut.build(pathElement: EScreen())
+    let eBuiltView = sut.build(pathElement: EScreen().asPathElement())
 
     guard case .e = eBuiltView else {
       XCTFail("Expected \(EScreen.self) to build Either.e. Got \(eBuiltView.debugDescription).")
@@ -893,7 +893,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: fScreen
-    let fBuiltView = sut.build(pathElement: FScreen())
+    let fBuiltView = sut.build(pathElement: FScreen().asPathElement())
 
     guard case .f = fBuiltView else {
       XCTFail("Expected \(FScreen.self) to build Either.f. Got \(fBuiltView.debugDescription).")
@@ -908,7 +908,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: gScreen
-    let gBuiltView = sut.build(pathElement: GScreen())
+    let gBuiltView = sut.build(pathElement: GScreen().asPathElement())
 
     guard case .g = gBuiltView else {
       XCTFail("Expected \(GScreen.self) to build Either.g. Got \(gBuiltView.debugDescription).")
@@ -923,7 +923,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: hScreen
-    let hBuiltView = sut.build(pathElement: HScreen())
+    let hBuiltView = sut.build(pathElement: HScreen().asPathElement())
 
     guard case .h = hBuiltView else {
       XCTFail("Expected \(HScreen.self) to build Either.h. Got \(hBuiltView.debugDescription).")
@@ -938,7 +938,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: iScreen
-    let iBuiltView = sut.build(pathElement: IScreen())
+    let iBuiltView = sut.build(pathElement: IScreen().asPathElement())
 
     guard case .i = iBuiltView else {
       XCTFail("Expected \(IScreen.self) to build Either.i. Got \(iBuiltView.debugDescription).")
@@ -952,7 +952,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }
@@ -1002,7 +1002,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     }
 
     // MARK: aScreen
-    let aBuiltView = sut.build(pathElement: AScreen())
+    let aBuiltView = sut.build(pathElement: AScreen().asPathElement())
 
     guard case .a = aBuiltView else {
       XCTFail("Expected \(AScreen.self) to build Either.a. Got \(aBuiltView.debugDescription).")
@@ -1017,7 +1017,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: bScreen
-    let bBuiltView = sut.build(pathElement: BScreen())
+    let bBuiltView = sut.build(pathElement: BScreen().asPathElement())
 
     guard case .b = bBuiltView else {
       XCTFail("Expected \(BScreen.self) to build Either.b. Got \(bBuiltView.debugDescription).")
@@ -1032,7 +1032,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: cScreen
-    let cBuiltView = sut.build(pathElement: CScreen())
+    let cBuiltView = sut.build(pathElement: CScreen().asPathElement())
 
     guard case .c = cBuiltView else {
       XCTFail("Expected \(CScreen.self) to build Either.c. Got \(cBuiltView.debugDescription).")
@@ -1047,7 +1047,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: dScreen
-    let dBuiltView = sut.build(pathElement: DScreen())
+    let dBuiltView = sut.build(pathElement: DScreen().asPathElement())
 
     guard case .d = dBuiltView else {
       XCTFail("Expected \(DScreen.self) to build Either.d. Got \(dBuiltView.debugDescription).")
@@ -1062,7 +1062,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: eScreen
-    let eBuiltView = sut.build(pathElement: EScreen())
+    let eBuiltView = sut.build(pathElement: EScreen().asPathElement())
 
     guard case .e = eBuiltView else {
       XCTFail("Expected \(EScreen.self) to build Either.e. Got \(eBuiltView.debugDescription).")
@@ -1077,7 +1077,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: fScreen
-    let fBuiltView = sut.build(pathElement: FScreen())
+    let fBuiltView = sut.build(pathElement: FScreen().asPathElement())
 
     guard case .f = fBuiltView else {
       XCTFail("Expected \(FScreen.self) to build Either.f. Got \(fBuiltView.debugDescription).")
@@ -1092,7 +1092,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: gScreen
-    let gBuiltView = sut.build(pathElement: GScreen())
+    let gBuiltView = sut.build(pathElement: GScreen().asPathElement())
 
     guard case .g = gBuiltView else {
       XCTFail("Expected \(GScreen.self) to build Either.g. Got \(gBuiltView.debugDescription).")
@@ -1107,7 +1107,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: hScreen
-    let hBuiltView = sut.build(pathElement: HScreen())
+    let hBuiltView = sut.build(pathElement: HScreen().asPathElement())
 
     guard case .h = hBuiltView else {
       XCTFail("Expected \(HScreen.self) to build Either.h. Got \(hBuiltView.debugDescription).")
@@ -1122,7 +1122,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: iScreen
-    let iBuiltView = sut.build(pathElement: IScreen())
+    let iBuiltView = sut.build(pathElement: IScreen().asPathElement())
 
     guard case .i = iBuiltView else {
       XCTFail("Expected \(IScreen.self) to build Either.i. Got \(iBuiltView.debugDescription).")
@@ -1137,7 +1137,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
     // MARK: jScreen
-    let jBuiltView = sut.build(pathElement: JScreen())
+    let jBuiltView = sut.build(pathElement: JScreen().asPathElement())
 
     guard case .j = jBuiltView else {
       XCTFail("Expected \(JScreen.self) to build Either.j. Got \(jBuiltView.debugDescription).")
@@ -1151,7 +1151,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
       as: .image
     )
 
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }

--- a/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+ConditionalTests.swift
+++ b/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+ConditionalTests.swift
@@ -3,19 +3,23 @@ import SwiftUI
 import XCTest
 
 final class NavigationTree_ConditionalTests: XCTestCase {
-  let pathElement = TestScreen(identifier: "", presentationStyle: .push)
+  struct NonMatching: Screen {
+    let presentationStyle: ScreenPresentationStyle = .push
+  }
+
+  let pathElement = TestScreen(identifier: "", presentationStyle: .push).asPathElement()
 
   // MARK: - ifScreen
   func test_ifScreen_builds_path_if_screen_matches() {
     var builtScreens = [AnyScreen]()
-    var builtPaths = [AnyScreen]()
+    var builtPaths = [NavigationPathElement]()
 
     let expectedScreens = [
-      pathElement.eraseToAnyScreen()
+      pathElement.content
     ]
 
     let expectedPaths = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
     let sut = EmptyNavigationTree()
@@ -38,10 +42,10 @@ final class NavigationTree_ConditionalTests: XCTestCase {
     }
 
     var builtScreens = [AnyScreen]()
-    var builtPaths = [AnyScreen]()
+    var builtPaths = [NavigationPathElement]()
 
     let expectedScreens = [AnyScreen]()
-    let expectedPaths = [AnyScreen]()
+    let expectedPaths = [NavigationPathElement]()
 
     let sut = EmptyNavigationTree()
       .If { (screen: TestScreen) in
@@ -52,23 +56,19 @@ final class NavigationTree_ConditionalTests: XCTestCase {
         }
       }
 
-    XCTAssertNil(sut.build(pathElement: NonMatching()))
+    XCTAssertNil(sut.build(pathElement: NonMatching().asPathElement()))
     XCTAssertEqual(expectedPaths, builtPaths)
     XCTAssertEqual(expectedScreens, builtScreens)
   }
 
   func test_ifScreen_builds_else_builder_if_screen_does_not_match() {
-    struct NonMatching: Screen {
-      let presentationStyle: ScreenPresentationStyle = .push
-    }
-
     var builtScreens = [AnyScreen]()
-    var builtPaths = [AnyScreen]()
-    var builtElsePaths = [AnyScreen]()
+    var builtPaths = [NavigationPathElement]()
+    var builtElsePaths = [NavigationPathElement]()
 
     let expectedScreens = [AnyScreen]()
-    let expectedPaths = [AnyScreen]()
-    let expectedElsePaths = [NonMatching().eraseToAnyScreen()]
+    let expectedPaths = [NavigationPathElement]()
+    let expectedElsePaths = [NonMatching().asPathElement()]
 
     let sut = EmptyNavigationTree()
       .If { (screen: TestScreen) in
@@ -85,7 +85,7 @@ final class NavigationTree_ConditionalTests: XCTestCase {
         }
       }
 
-    XCTAssertNotNil(sut.build(pathElement: NonMatching()))
+    XCTAssertNotNil(sut.build(pathElement: NonMatching().asPathElement()))
     XCTAssertEqual(expectedPaths, builtPaths)
     XCTAssertEqual(expectedScreens, builtScreens)
     XCTAssertEqual(expectedElsePaths, builtElsePaths)

--- a/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+EmptyTests.swift
+++ b/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+EmptyTests.swift
@@ -13,6 +13,6 @@ final class NavigationTree_EmptyTests: XCTestCase {
     
     let sut = TestNavigationTree()
     
-    XCTAssertNil(sut.build(pathElement: pathElement))
+    XCTAssertNil(sut.build(pathElement: pathElement.asPathElement()))
   }
 }

--- a/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+Screen.swift
+++ b/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+Screen.swift
@@ -11,11 +11,11 @@ final class NavigationTree_ScreenTests: XCTestCase {
       let presentationStyle: ScreenPresentationStyle = .push
     }
 
-    var nestingPathBuilderInvocations = [AnyScreen]()
+    var nestingPathBuilderInvocations = [NavigationPathElement]()
 
-    let pathElement = NonMatching()
+    let pathElement = NonMatching().asPathElement()
 
-    let expectedNestingPathBuilderInvocations = [AnyScreen]()
+    let expectedNestingPathBuilderInvocations = [NavigationPathElement]()
     
     let sut = EmptyNavigationTree().Screen(
       content: { (screen: TestScreen) in EmptyView() },
@@ -32,7 +32,7 @@ final class NavigationTree_ScreenTests: XCTestCase {
   }
 
   func test_closure_based_matching_screen_buildsPath() {
-    let pathElement = TestScreen(identifier: "0", presentationStyle: .push)
+    let pathElement = TestScreen(identifier: "0", presentationStyle: .push).asPathElement()
 
     let sut = EmptyNavigationTree().Screen(
       content: { (screen: TestScreen) in EmptyView() }
@@ -42,7 +42,7 @@ final class NavigationTree_ScreenTests: XCTestCase {
   }
 
   func test_closure_based_onAppear_in_built_view_calls_passed_action() {
-    let pathElement = TestScreen(identifier: "0", presentationStyle: .push)
+    let pathElement = TestScreen(identifier: "0", presentationStyle: .push).asPathElement()
 
     var onAppearInvocations = [Bool]()
     let expectedOnAppearInvocations = [
@@ -65,11 +65,11 @@ final class NavigationTree_ScreenTests: XCTestCase {
   }
 
   func test_closure_based_next_in_built_view_calls_nesting_path_builder() {
-    let pathElement = TestScreen(identifier: "0", presentationStyle: .push)
+    let pathElement = TestScreen(identifier: "0", presentationStyle: .push).asPathElement()
 
-    var nextInvocations = [AnyScreen]()
+    var nextInvocations = [NavigationPathElement]()
     let expectedNextInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
     let sut = EmptyNavigationTree().Screen(
@@ -83,7 +83,7 @@ final class NavigationTree_ScreenTests: XCTestCase {
     )
 
     let builtView = sut.build(pathElement: pathElement)
-    _ = builtView?.buildSuccessor(pathElement.eraseToAnyScreen())
+    _ = builtView?.buildSuccessor(pathElement)
 
     XCTAssertEqual(expectedNextInvocations, nextInvocations)
   }
@@ -94,11 +94,11 @@ final class NavigationTree_ScreenTests: XCTestCase {
       let presentationStyle: ScreenPresentationStyle = .push
     }
 
-    var nestingPathBuilderInvocations = [AnyScreen]()
+    var nestingPathBuilderInvocations = [NavigationPathElement]()
 
-    let pathElement = NonMatching()
+    let pathElement = NonMatching().asPathElement()
 
-    let expectedNestingPathBuilderInvocations = [AnyScreen]()
+    let expectedNestingPathBuilderInvocations = [NavigationPathElement]()
 
     let sut = EmptyNavigationTree().Screen(
       TestScreen.self,
@@ -116,7 +116,7 @@ final class NavigationTree_ScreenTests: XCTestCase {
   }
 
   func test_type_based_matching_screen_buildsPath() {
-    let pathElement = TestScreen(identifier: "0", presentationStyle: .push)
+    let pathElement = TestScreen(identifier: "0", presentationStyle: .push).asPathElement()
 
     let sut = EmptyNavigationTree().Screen(
       TestScreen.self,
@@ -129,7 +129,7 @@ final class NavigationTree_ScreenTests: XCTestCase {
   }
 
   func test_type_based_onAppear_in_built_view_calls_passed_action() {
-    let pathElement = TestScreen(identifier: "0", presentationStyle: .push)
+    let pathElement = TestScreen(identifier: "0", presentationStyle: .push).asPathElement()
 
     var onAppearInvocations = [Bool]()
     let expectedOnAppearInvocations = [
@@ -153,11 +153,11 @@ final class NavigationTree_ScreenTests: XCTestCase {
   }
 
   func test_type_based_next_in_built_view_calls_nesting_path_builder() {
-    let pathElement = TestScreen(identifier: "0", presentationStyle: .push)
+    let pathElement = TestScreen(identifier: "0", presentationStyle: .push).asPathElement()
 
-    var nextInvocations = [AnyScreen]()
+    var nextInvocations = [NavigationPathElement]()
     let expectedNextInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
     let sut = EmptyNavigationTree().Screen(
@@ -172,7 +172,7 @@ final class NavigationTree_ScreenTests: XCTestCase {
     )
 
     let builtView = sut.build(pathElement: pathElement)
-    _ = builtView?.buildSuccessor(pathElement.eraseToAnyScreen())
+    _ = builtView?.buildSuccessor(pathElement)
 
     XCTAssertEqual(expectedNextInvocations, nextInvocations)
   }

--- a/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+WildcardTests.swift
+++ b/Tests/ComposableNavigatorTests/NavigationTree/NavigationTree+WildcardTests.swift
@@ -10,12 +10,12 @@ final class NavigationTree_WildcardTest: XCTestCase {
       let presentationStyle: ScreenPresentationStyle = .push
     }
 
-    let pathElement = NonMatching().eraseToAnyScreen()
+    let pathElement = NonMatching().asPathElement()
 
     let sut = EmptyNavigationTree().Wildcard(
       screen: testScreen,
       pathBuilder: _PathBuilder { path -> EmptyView? in
-        let expected = self.testScreen.eraseToAnyScreen()
+        let expected = self.testScreen.asPathElement()
 
         XCTAssertEqual(expected, path)
         return EmptyView()
@@ -31,13 +31,13 @@ final class NavigationTree_WildcardTest: XCTestCase {
     let sut = EmptyNavigationTree().Wildcard(
       screen: testScreen,
       pathBuilder: _PathBuilder { pathElement -> EmptyView? in
-        XCTAssertEqual(self.testScreen.eraseToAnyScreen(), pathElement)
+        XCTAssertEqual(self.testScreen.asPathElement(), pathElement)
         return EmptyView()
       }
     )
 
     let builtScreen = sut.build(
-      pathElement: testScreen
+      pathElement: testScreen.asPathElement()
     )
 
     XCTAssertNotNil(builtScreen)

--- a/Tests/ComposableNavigatorTests/NavigationTree/NavigationTreeBuilder+AnyOf.swift.gyb
+++ b/Tests/ComposableNavigatorTests/NavigationTree/NavigationTreeBuilder+AnyOf.swift.gyb
@@ -48,7 +48,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
   innerCharLower = genericCharactersLower[inner]
 }%
     // MARK: ${innerCharLower}Screen
-    let ${innerCharLower}BuiltView = sut.build(pathElement: ${innerChar}Screen())
+    let ${innerCharLower}BuiltView = sut.build(pathElement: ${innerChar}Screen().asPathElement())
 
     guard case .${innerCharLower} = ${innerCharLower}BuiltView else {
       XCTFail("Expected \(${innerChar}Screen.self) to build Either.${innerCharLower}. Got \(${innerCharLower}BuiltView.debugDescription).")
@@ -63,7 +63,7 @@ final class PathBuilder_AnyOfTests: XCTestCase {
     )
 
 % end
-    let nonMatchingBuilt = sut.build(pathElement: NonMatching())
+    let nonMatchingBuilt = sut.build(pathElement: NonMatching().asPathElement())
 
     XCTAssertNil(nonMatchingBuilt)
   }

--- a/Tests/ComposableNavigatorTests/Navigator/Navigator+DebugTests.swift
+++ b/Tests/ComposableNavigatorTests/Navigator/Navigator+DebugTests.swift
@@ -2,9 +2,12 @@
 import XCTest
 
 final class Navigator_DebugTests: XCTestCase {
+  let previous = [NavigationPathElement]()
+  let current = [NavigationPathElement]()
+
   func test_path_returns_underlying_path() {
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) }
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) }
     )
 
     let sut = underlyingNavigator.debug()
@@ -23,12 +26,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.GoToInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       goToInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent go(to: \(expectedScreen), on: \(expectedID)).\nNew path:"
@@ -56,12 +59,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.GoToInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       goToInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent go(to: \(expectedScreen), on: \(expectedScreen)).\nNew path:"
@@ -91,12 +94,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.GoToPathInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       goToPathInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent go(to path: \([expectedScreen]), on: \(expectedID)).\nNew path:"
@@ -124,12 +127,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.GoToPathInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       goToPathInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent go(to path: \([expectedScreen]), on: \(expectedScreen)).\nNew path:"
@@ -158,12 +161,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.GoBackToInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       goBackToInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent goBack(to: \(expectedID)).\nNew path:"
@@ -191,12 +194,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.GoBackToInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       goBackToInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent goBack(to: \(expectedScreen)).\nNew path:"
@@ -225,12 +228,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.ReplacePathInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       replacePathInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent replace(path: \([expectedScreen])).\nNew path:"
@@ -259,12 +262,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.DismissInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       dismissInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent dismiss(id: \(expectedID)).\nNew path:"
@@ -292,12 +295,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.DismissInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       dismissInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent dismiss(screen: \(expectedScreen)).\nNew path:"
@@ -326,12 +329,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.DismissSuccessorInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       dismissSuccessorInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent dismissSuccessor(of: \(expectedID)).\nNew path:"
@@ -359,12 +362,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.DismissSuccessorInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       dismissSuccessorInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent dismissSuccessor(of: \(expectedScreen)).\nNew path:"
@@ -394,12 +397,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.ReplaceContentInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       replaceContentInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent replaceContent(of: \(expectedID), with: \(expectedScreen)).\nNew path:"
@@ -427,12 +430,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.ReplaceScreenInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       replaceScreenInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent replace(screen: \(expectedScreen), with: \(expectedScreen)).\nNew path:"
@@ -461,12 +464,12 @@ final class Navigator_DebugTests: XCTestCase {
     var invocations = [Navigator.DidAppearInvocation]()
 
     let underlyingNavigator = Navigator.mock(
-      path: { PathUpdate(previous: [], current: []) },
+      path: { NavigationPathUpdate(previous: self.previous, current: self.current) },
       didAppearInvoked: { invocation in invocations.append(invocation) }
     )
 
     var loggedMessages = [String]()
-    var dumpedPaths = [PathUpdate]()
+    var dumpedPaths = [NavigationPathUpdate]()
 
     let expectedLoggedMessages = [
       "Sent didAppear(id: \(expectedID)).\nNew path:"

--- a/Tests/ComposableNavigatorTests/Navigator/NavigatorDatasourceTests.swift
+++ b/Tests/ComposableNavigatorTests/Navigator/NavigatorDatasourceTests.swift
@@ -40,7 +40,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false),
         ],
@@ -64,7 +64,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false),
         ],
@@ -104,7 +104,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -154,7 +154,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -201,7 +201,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -248,7 +248,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -292,7 +292,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -330,7 +330,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -366,7 +366,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false)
@@ -392,7 +392,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false)
@@ -420,7 +420,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -444,7 +444,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -476,7 +476,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -512,7 +512,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -552,7 +552,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(previous: [], current: path)
+      NavigationPathUpdate(previous: [], current: path)
     )
   }
 
@@ -580,7 +580,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: [
           IdentifiedScreen(
@@ -629,7 +629,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(
@@ -672,7 +672,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -693,7 +693,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -719,7 +719,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false),
@@ -747,7 +747,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false),
@@ -776,7 +776,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -803,7 +803,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -829,7 +829,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false),
@@ -857,7 +857,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: self.root, hasAppeared: false),
@@ -886,7 +886,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -913,7 +913,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -938,7 +938,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: path
       )
@@ -975,7 +975,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: expectedPath
       )
@@ -1007,7 +1007,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: expectedPath
       )
@@ -1044,7 +1044,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: expectedPath
       )
@@ -1079,7 +1079,7 @@ final class NavigatorDatasourceTests: XCTestCase {
     
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: [],
         current: expectedPath
       )
@@ -1105,7 +1105,7 @@ final class NavigatorDatasourceTests: XCTestCase {
 
     XCTAssertEqual(
       sut.path,
-      PathUpdate(
+      NavigationPathUpdate(
         previous: previousPath,
         current: [
           IdentifiedScreen(id: .root, content: root, hasAppeared: false),

--- a/Tests/ComposableNavigatorTests/Navigator/Path/PathElement/NavigationPathElementTests.swift
+++ b/Tests/ComposableNavigatorTests/Navigator/Path/PathElement/NavigationPathElementTests.swift
@@ -1,0 +1,73 @@
+@testable import ComposableNavigator
+import XCTest
+
+final class NavigationPathElement_Tests: XCTestCase {
+  let screenID = ScreenID()
+  let content = TestScreen(
+    identifier: "",
+    presentationStyle: .push
+  )
+
+  // MARK: - Screen path element
+  func test_screen_id_equals_wrapped_screen_id() {
+    let sut = NavigationPathElement.screen(
+      IdentifiedScreen(
+        id: screenID,
+        content: content,
+        hasAppeared: false
+      )
+    )
+
+    XCTAssertEqual(screenID, sut.id)
+  }
+
+  func test_screen_ids_contains_only_screen_id() {
+    let expectedIDs = Set<ScreenID>([screenID])
+
+    let sut = NavigationPathElement.screen(
+      IdentifiedScreen(
+        id: screenID,
+        content: content,
+        hasAppeared: false
+      )
+    )
+
+    XCTAssertEqual(expectedIDs, sut.ids())
+  }
+
+  func test_screen_content_equals_wrapped_content() {
+    let expectedContent = content.eraseToAnyScreen()
+
+    let sut = NavigationPathElement.screen(
+      IdentifiedScreen(
+        id: screenID,
+        content: content,
+        hasAppeared: false
+      )
+    )
+
+    XCTAssertEqual(expectedContent, sut.content)
+  }
+
+  func test_screen_hasAppeared_equals_wrapped_screen() {
+    var sut = NavigationPathElement.screen(
+      IdentifiedScreen(
+        id: screenID,
+        content: content,
+        hasAppeared: false
+      )
+    )
+
+    XCTAssertFalse(sut.hasAppeared)
+
+    sut = NavigationPathElement.screen(
+      IdentifiedScreen(
+        id: screenID,
+        content: content,
+        hasAppeared: true
+      )
+    )
+
+    XCTAssertTrue(sut.hasAppeared)
+  }
+}

--- a/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+BeforeBuildTests.swift
+++ b/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+BeforeBuildTests.swift
@@ -4,7 +4,10 @@ import XCTest
 
 final class PathBuilder_BeforeBuildTests: XCTestCase {
   func test_executes_perform_closure_before_build() {
-    let pathElement = TestScreen(identifier: "", presentationStyle: .push)
+    let pathElement = TestScreen(
+        identifier: "",
+        presentationStyle: .push
+    ).asPathElement()
 
     let pathBuilder = PathBuilders.empty
     var performClosureCalled = false

--- a/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+ConditionalTests.swift
+++ b/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+ConditionalTests.swift
@@ -3,14 +3,14 @@ import SwiftUI
 import XCTest
 
 final class PathBuilder_Conditional_Tests: XCTestCase {
-  let pathElement = TestScreen(identifier: "", presentationStyle: .push)
+  let pathElement = TestScreen(identifier: "", presentationStyle: .push).asPathElement()
 
   // MARK: - If
   func test_if_builds_then_builder_if_condition_is_true() {
-    var thenBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
 
     let expectedThenBuilderInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
     let sut = PathBuilders
@@ -27,14 +27,14 @@ final class PathBuilder_Conditional_Tests: XCTestCase {
   }
 
   func test_ifElse_builds_then_builder_if_condition_is_true() {
-    var thenBuilderInvocations = [AnyScreen]()
-    var elseBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
+    var elseBuilderInvocations = [NavigationPathElement]()
 
     let expectedThenBuilderInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
-    let expectedElseBuilderInvocations = [AnyScreen]()
+    let expectedElseBuilderInvocations = [NavigationPathElement]()
 
     let sut = PathBuilders
       .if (
@@ -56,13 +56,13 @@ final class PathBuilder_Conditional_Tests: XCTestCase {
   }
 
   func test_ifElse_builds_else_builder_if_condition_is_false() {
-    var thenBuilderInvocations = [AnyScreen]()
-    var elseBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
+    var elseBuilderInvocations = [NavigationPathElement]()
 
-    let expectedThenBuilderInvocations = [AnyScreen]()
+    let expectedThenBuilderInvocations = [NavigationPathElement]()
 
     let expectedElseBuilderInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
     let sut = PathBuilders.if (
@@ -85,9 +85,9 @@ final class PathBuilder_Conditional_Tests: XCTestCase {
   // MARK: - ifLet
   func test_ifLet_without_elseBuilder_builds_thenBuilder_ifLetContent_not_nil() {
     let letContent = 1
-    var thenBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
     let expectedThenBuilderInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
     var unwrappedContents = [Int]()
@@ -112,14 +112,14 @@ final class PathBuilder_Conditional_Tests: XCTestCase {
 
   func test_ifLet_builds_thenBuilder_ifLetContent_not_nil() {
     let letContent = 1
-    var thenBuilderInvocations = [AnyScreen]()
-    var elseBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
+    var elseBuilderInvocations = [NavigationPathElement]()
 
     let expectedThenBuilderInvocations = [
-      pathElement.eraseToAnyScreen()
+      pathElement
     ]
 
-    let expectedElseBuilderInvocations = [AnyScreen]()
+    let expectedElseBuilderInvocations = [NavigationPathElement]()
 
     var unwrappedContents = [Int]()
     let expectedUnwrappedContents = [1]
@@ -149,12 +149,12 @@ final class PathBuilder_Conditional_Tests: XCTestCase {
   }
 
   func test_ifLet_builds_elseBuilder_ifLetContent_is_nil() {
-    var thenBuilderInvocations = [AnyScreen]()
-    var elseBuilderInvocations = [AnyScreen]()
+    var thenBuilderInvocations = [NavigationPathElement]()
+    var elseBuilderInvocations = [NavigationPathElement]()
 
-    let expectedThenBuilderInvocations = [AnyScreen]()
+    let expectedThenBuilderInvocations = [NavigationPathElement]()
 
-    let expectedElseBuilderInvocations = [pathElement.eraseToAnyScreen()]
+    let expectedElseBuilderInvocations = [pathElement]
 
     var unwrappedContents = [Int]()
     let expectedUnwrappedContents = [Int]()

--- a/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+EmptyTests.swift
+++ b/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+EmptyTests.swift
@@ -7,6 +7,6 @@ final class PathBuilder_EmptyTests: XCTestCase {
     
     let sut = PathBuilders.empty
 
-    XCTAssertNil(sut.build(pathElement: pathElement))
+    XCTAssertNil(sut.build(pathElement: pathElement.asPathElement()))
   }
 }

--- a/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+EraseCircularPathTests.swift
+++ b/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+EraseCircularPathTests.swift
@@ -20,7 +20,7 @@ final class PathBuilder_EraseCircularPathTests: XCTestCase {
       pathElement: TestScreen(
         identifier: "",
         presentationStyle: .push
-      )
+      ).asPathElement()
     )
 
     XCTAssertNotNil(built)
@@ -34,7 +34,7 @@ final class PathBuilder_EraseCircularPathTests: XCTestCase {
       pathElement: TestScreen(
         identifier: "",
         presentationStyle: .push
-      )
+      ).asPathElement()
     )
 
     XCTAssertNil(built)

--- a/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+OnDismissTests.swift
+++ b/Tests/ComposableNavigatorTests/PathBuilder/PathBuilder+OnDismissTests.swift
@@ -10,21 +10,21 @@ final class PathBuilder_OnDismissTest: XCTestCase {
     let presentationStyle: ScreenPresentationStyle = .push
   }
 
-  func testScreen(with id: String) -> IdentifiedScreen {
-    IdentifiedScreen(
-      id: testScreenID,
-      content: TestScreen(identifier: id, presentationStyle: .push),
-      hasAppeared: false
-    )
-  }
+  let testScreen = TestScreen(identifier: "0", presentationStyle: .push)
 
-  lazy var pathElement = testScreen(with: "0").content
+  lazy var identifiedTestScreen = IdentifiedScreen(
+    id: testScreenID,
+      content: testScreen,
+    hasAppeared: false
+  )
+
+  lazy var pathElement = testScreen.asPathElement()
 
   func dataSource() -> Navigator.Datasource {
     Navigator.Datasource(
       path: [
         IdentifiedScreen(id: .root, content: RootScreen(), hasAppeared: true),
-        testScreen(with: "0")
+        identifiedTestScreen
       ]
     )
   }
@@ -45,7 +45,7 @@ final class PathBuilder_OnDismissTest: XCTestCase {
           dismissCalled = true
           XCTAssertEqual(
             screen,
-            self.testScreen(with: "0").content
+            self.identifiedTestScreen.content
           )
         }
       )
@@ -77,7 +77,7 @@ final class PathBuilder_OnDismissTest: XCTestCase {
           dismissCalled = true
           XCTAssertEqual(
             screen,
-            self.testScreen(with: "0").content.unwrap()
+            self.identifiedTestScreen.content.unwrap()
           )
         }
       )

--- a/Tests/ComposableNavigatorTests/Screen/RootTests.swift
+++ b/Tests/ComposableNavigatorTests/Screen/RootTests.swift
@@ -7,7 +7,7 @@ final class RootTests: XCTestCase {
   func test_root_wraps_content_in_navigation_view() {
     let rootScreen = TestScreen(identifier: "0", presentationStyle: .push)
 
-    let expectedPath = rootScreen.eraseToAnyScreen()
+    let expectedPath = rootScreen.asPathElement()
     var onAppearCalled = false
 
     let root = Root(


### PR DESCRIPTION
[//]: # (Link the resolved Github issue.)
In preparation of #19.

## Problem
[//]: # (Explain why this pull request is necessary.)
Currently, the NavigationPath is a list of IdentifiedScreens. However, we will need to store more information in NavigationPathElements in the future to enable Tabbed screens and overlays. Also, paths need to be 'split-able' into multiple levels, allowing path elements to contain paths

## Solution
[//]: # (Explain how you solved the problem.)
Introduce the Either type NavigationPathElement that exposes a common interface that all navigation path elements need to implement. This PR does not contain any work towards tabbed path builders but is only preparing the transition. 