### PR TITLE
Fixes compilation of vanilla SwiftUI example

### DIFF
--- a/Example/Vanilla SwiftUI Example/Vanilla SwiftUI Example.xcodeproj/project.pbxproj
+++ b/Example/Vanilla SwiftUI Example/Vanilla SwiftUI Example.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		527E31E527066754005BDCFE /* ComposableNavigator in Frameworks */ = {isa = PBXBuildFile; productRef = 527E31E427066754005BDCFE /* ComposableNavigator */; };
 		E04E139925F7CC560080D76C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E04E139825F7CC560080D76C /* Assets.xcassets */; };
 		E04E139C25F7CC560080D76C /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E04E139B25F7CC560080D76C /* Preview Assets.xcassets */; };
 		E04E13AA25F7CCA90080D76C /* CapacityView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04E13A425F7CCA90080D76C /* CapacityView.swift */; };
@@ -14,8 +15,6 @@
 		E04E13AC25F7CCA90080D76C /* Train.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04E13A625F7CCA90080D76C /* Train.swift */; };
 		E04E13AD25F7CCA90080D76C /* DetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04E13A725F7CCA90080D76C /* DetailView.swift */; };
 		E04E13AE25F7CCA90080D76C /* Vanilla_ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = E04E13A825F7CCA90080D76C /* Vanilla_ExampleApp.swift */; };
-		E04E13B325F7CCBC0080D76C /* ComposableNavigator.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E04E13B225F7CCBC0080D76C /* ComposableNavigator.framework */; };
-		E04E13B425F7CCBC0080D76C /* ComposableNavigator.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E04E13B225F7CCBC0080D76C /* ComposableNavigator.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -25,7 +24,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				E04E13B425F7CCBC0080D76C /* ComposableNavigator.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -50,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				E04E13B325F7CCBC0080D76C /* ComposableNavigator.framework in Frameworks */,
+				527E31E527066754005BDCFE /* ComposableNavigator in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -122,6 +120,9 @@
 			dependencies = (
 			);
 			name = "Vanilla SwiftUI Example";
+			packageProductDependencies = (
+				527E31E427066754005BDCFE /* ComposableNavigator */,
+			);
 			productName = "Vanilla SwiftUI Example";
 			productReference = E04E139125F7CC550080D76C /* Vanilla SwiftUI Example.app */;
 			productType = "com.apple.product-type.application";
@@ -372,6 +373,13 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		527E31E427066754005BDCFE /* ComposableNavigator */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = ComposableNavigator;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = E04E138925F7CC550080D76C /* Project object */;
 }


### PR DESCRIPTION
Resolves #75 by referencing the local SPM package instead of ComposableNavigator.framework.